### PR TITLE
Add basic TypeScript type definitions

### DIFF
--- a/src/Router.d.ts
+++ b/src/Router.d.ts
@@ -1,0 +1,30 @@
+interface RouteHandler<TRequest> {
+  (request: TRequest & Request): any;
+}
+
+interface Route {
+  <TRequest>(path: string, handler: RouteHandler<TRequest & Request>): Router;
+}
+
+interface Request {
+  path?: string;
+  method: string;
+  url: string;
+  query: {
+    [key: string]: string;
+  };
+  params: {
+    [key: string]: string;
+  };
+}
+
+interface Router {
+  handle: (request: Request) => any;
+  get: Route;
+  put: Route;
+  post: Route;
+  patch: Route;
+  delete: Route;
+}
+
+export function Router(): Router;


### PR DESCRIPTION
This PR adds basic ambient type declarations for `Router` to improve code hinting for the dynamic/proxied methods and make it easier to code with `itty-router`. 

I'm not 100% certain how this would actually fare working in a TypeScript project, but at the very least it should help in TS-powered editors like VS Code by giving you better IntelliSense. 