### PR TITLE
v1.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "scripts": {
     "test": "jest --verbose --coverage",
+    "verify": "yarn build && yarn test",
     "dev": "yarn test - --watch",
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls",
     "prerelease": "echo releasing...",

--- a/prebuild.js
+++ b/prebuild.js
@@ -1,16 +1,18 @@
 const { readFileSync, writeFileSync } = require('fs-extra')
 
 const base = readFileSync('./src/itty-router.js', { encoding: 'utf-8' })
-const minifiedBase = base.replace(/\bhandlers\b/g, 'hs')
-  .replace(/\bhandler\b/g, 'h')
-  .replace(/([^\.])obj\b/g, '$1o')
-  .replace(/([^\.])attr\b/g, '$1a')
-  .replace(/([^\.])route\b/g, '$1p')
-  .replace(/([^\.])request\b/g, '$1q')
-  .replace(/([^\.])response\b/g, '$1s')
-  .replace(/([^\.])match\b/g, '$1m')
-  .replace(/([^\.])prop\b/g, '$1k')
-  .replace(/([^\.])url\b/g, '$1u')
+const minifiedBase = base
+  .replace(/\bhandlers\b/g, 'hs') // Handler(S)
+  .replace(/\bhandler\b/g, 'h') // Handler
+  .replace(/([^\.])obj\b/g, '$1t') // Target
+  .replace(/([^\.])options\b/g, '$1o') // Options
+  .replace(/([^\.])attr\b/g, '$1a') // Attr
+  .replace(/([^\.])route\b/g, '$1p') // Path
+  .replace(/([^\.])request\b/g, '$1q') // reQuest
+  .replace(/([^\.])response\b/g, '$1s') // reSponse
+  .replace(/([^\.])match\b/g, '$1m') // Match
+  .replace(/([^\.])prop\b/g, '$1k') // Key
+  .replace(/([^\.])url\b/g, '$1u') // Url
 writeFileSync('./dist/itty-router.js', minifiedBase)
 console.log('minifying variables --> dist/itty-router.js')
 

--- a/src/itty-router.js
+++ b/src/itty-router.js
@@ -1,26 +1,26 @@
-const Router = () =>
+const Router = (options = {}) =>
   new Proxy({}, {
-    get: (obj, prop) => prop === 'handle' 
+    get: (obj, prop) => prop === 'handle'
       ? async (request) => {
-        for ([route, handlers] of obj[(request.method || 'GET').toLowerCase()] || []) {
-          if (match = (url = new URL(request.url)).pathname.match(route)) { // route matched
-            request.params = match.groups
-            request.query = Object.fromEntries(url.searchParams.entries())
+          for ([route, handlers] of obj[(request.method || 'GET').toLowerCase()] || []) {
+            if (match = (url = new URL(request.url)).pathname.match(route)) {
+              request.params = match.groups
+              request.query = Object.fromEntries(url.searchParams.entries())
 
-            for (handler of handlers) {
-              if ((response = await handler(request)) !== undefined) return response
+              for (handler of handlers) {
+                if ((response = await handler(request)) !== undefined) return response
+              }
             }
           }
         }
-      }
-    : (route, ...handlers) =>
-        (obj[prop] = obj[prop] || []).push([
-          `^${route
-            .replace('*', '.*')
-            .replace(/(\/:([^\/\?]+)(\?)?)/gi, '/$3(?<$2>[^/]+)$3')}$`,
-          handlers
-        ]) && obj
-    }
-  )
+      : (route, ...handlers) =>
+          (obj[prop] = obj[prop] || []).push([
+            `^${(options.base || '')+route
+              .replace(/(\/?)\*/g, '($1.*)?')
+              .replace(/(\/:([^\/\?]+)(\?)?)/gi, '/$3(?<$2>[^/]+)$3')
+            }$`,
+            handlers
+          ]) && obj
+  })
 
 module.exports = { Router }


### PR DESCRIPTION
# Changelog
### Features
- Added single config option to `Router({ base: '/some/path' })` for route prefixing
- Verified wildcards work in the middle of path (e.g. `/foo/*/end` matches `/foo/bar/baz/end`)
### Fix
- trailing wildcards (often used in middleware or for sub routers) now properly routes without requiring trailing slash (e.g. `/foo/*` should match `/foo`)