### PR TITLE
fix: Property 'params' does not exist on type 'Request'

### DIFF
--- a/src/itty-router.d.ts
+++ b/src/itty-router.d.ts
@@ -6,9 +6,15 @@ interface Route {
   <TRequest>(path: string, ...handlers: RouteHandler<TRequest & Request>[]): Router
 }
 
+type Obj = {
+  [propName: string]: string
+}
+
 interface Request {
   method?: string
   url: string
+  params?: Obj
+  query?: Obj
 }
 
 interface Router {


### PR DESCRIPTION
Fixed missing params when use TS.

![image](https://user-images.githubusercontent.com/11495164/96424280-13cd9300-122d-11eb-91cc-887d2c66cacc.png)
