### PR TITLE
pass extra args to handlers

### DIFF
--- a/src/itty-router.js
+++ b/src/itty-router.js
@@ -1,14 +1,14 @@
 const Router = (options = {}) =>
   new Proxy(options, {
     get: (obj, prop, receiver) => prop === 'handle'
-      ? async request => {
+      ? async (request, ...args) => {
           for ([route, handlers] of obj[(request.method || 'GET').toLowerCase()] || []) {
             if (match = (url = new URL(request.url)).pathname.match(route)) {
               request.params = match.groups
               request.query = Object.fromEntries(url.searchParams.entries())
 
               for (handler of handlers) {
-                if ((response = await handler(request)) !== undefined) return response
+                if ((response = await handler(request, ...args)) !== undefined) return response
               }
             }
           }

--- a/src/itty-router.spec.js
+++ b/src/itty-router.spec.js
@@ -64,6 +64,7 @@ describe('Router', () => {
   })
 
   describe('.handle({ method = \'GET\', url })', () => {
+
     it('returns { path, query } from match', () => {
       const route = routes.find(r => r.path === '/foo/:id')
       router.handle(buildRequest({ path: '/foo/13?foo=bar&cat=dog' }))
@@ -307,6 +308,22 @@ describe('Router', () => {
           .get('/foo', jest.fn())
 
       }).not.toThrow()
+    })
+  })
+
+  describe('.handle({ method = \'GET\', url }, ...args)', () => {
+    it('passes extra args to each handler', async () => {
+      const r = Router()
+      const h = (req, a, b) => { req.a = a; req.b = b }
+      const originalA = 'A'
+      const originalB = {}
+      r.get('*', h)
+      const req = buildRequest({ path: '/foo', })
+
+      await r.handle(req, originalA, originalB)
+
+      expect(req.a).toBe(originalA)
+      expect(req.b).toBe(originalB)
     })
   })
 })


### PR DESCRIPTION
This allows the user to pass arbitrary arguments to handlers via `.handle`.

For instance, if you'd like your final `*` route to use Cloudflare's [getAssetsFromKV](https://github.com/cloudflare/kv-asset-handler#getassetfromkv), it needs access to the original `event` object, not just the `request`:

```js
import { Router } from 'itty-router'
import { getAssetFromKV } from "@cloudflare/kv-asset-handler"

const router = Router()

router
    .get('/foo', () => new Response('Foo Index!'))
    .get('/foo/:id', ({ params }) => new Response(`Details for item ${params.id}.`))
    .get('*', serveStaticAssets)

addEventListener('fetch', event => {
    event.respondWith(router.handle(event.request, event))
})

async function serveStaticAssets(req, event) {
    try { return await getAssetFromKV(event) }
    catch (err) { }
}
```