### PR TITLE
Fix route logic bugs and minifier shadowing bug

### DIFF
--- a/src/itty-router.js
+++ b/src/itty-router.js
@@ -2,7 +2,7 @@ const Router = (options = {}) =>
   new Proxy(options, {
     get: (obj, prop, receiver) => prop === 'handle'
       ? async (request, ...args) => {
-          for ([route, handlers] of obj.routes.filter(r => r[0] === request.method || 'ALL')) {
+          for ([route, handlers] of obj.routes.filter(x => x[2] === request.method || x[2] === 'ALL')) {
             if (match = (url = new URL(request.url)).pathname.match(route)) {
               request.params = match.groups
               request.query = Object.fromEntries(url.searchParams.entries())


### PR DESCRIPTION
The route filter had three bugs:

1) Checked the wrong array entry to find the method (0 instead of 2)
2) Did not make correct use of ||
3) The variable named r was shadowing the request variable after
   minification

Three bugs in one line, but that is what you would expect from such
beautiful minimalistic code where every little character counts :-D

Taking this opportunity to thank you for this absolutely awesome router @kwhitley! 🥇

Just love how you managed to cram so much power into so few bytes. Was a pleasure to dig into the enormous code base and find the bug that was causing weird behaviour for me 😄 - learned a lot!
