### PR TITLE
Tweaks on top of taralx PR... 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 Until this library makes it to a production release of v1.x, **minor versions may contain breaking changes to the API**.  After v1.x, semantic versioning will be honored, and breaking changes will only occur under the umbrella of a major version bump.
 
+- **v2.4.0** - HUGE internal code-golfing refactor thanks to [@taralx](https://github.com/taralx)!  Super cool work on this!!!
 - **v2.3.10** - fix: dots now properly escaped (e.g. /image.jpg should not match /imageXjpg)
 - **v2.3.9** - dev fixes: [@taralx](https://github.com/taralx) improved QOL issues for test writers and dev installers
 - **v2.3.7** - fix: :id.:format not resolving (only conditional format would match)

--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ GET /todos/jane?limit=2&page=1
   // attach the router "handle" to the event handler
   addEventListener('fetch', event =>
     event.respondWith(
-      router.handle(event.request).catch(errorHandler)
+      router
+        .handle(event.request)
+        .catch(errorHandler)
     )
   )
   ```

--- a/README.md
+++ b/README.md
@@ -319,11 +319,15 @@ router
 ```
 
 ### Manual Routes
-Thanks to a beautiful refactor by @taralx, we've added the ability to fully preload or push manual routes with hand-writted regex.  This is useful because out of the box, only a tiny subset of regex "accidentally" works with itty, given that... you know... it's the thing writing regex for you in the first place.  If you have a problem route that needs custom regex though, you're in luck!  You can now inject your own routes using the far-less-user-friendly-but-totally-possible manual injection method (below).
+Thanks to a pretty sick refactor by [@taralx](https://github.com/taralx), we've added the ability to fully preload or push manual routes with hand-writted regex.
+
+Why is this useful?
+
+Out of the box, only a tiny subset of regex "accidentally" works with itty, given that... you know... it's the thing writing regex for you in the first place.  If you have a problem route that needs custom regex though, you can now manually give itty the exact regex it will match against, through the far-less-user-friendly-but-totally-possible manual injection method (below).
 
 Individual routes are defined as an array of: `[ method: string, match: RegExp, handlers: Array<function> ]`
 
-###### Manually push a custom route
+###### EXAMPLE 1: Manually push a custom route
 ```js
 import { Router } from 'itty-router'
 
@@ -346,20 +350,21 @@ await router.handle({ method: 'GET', url: 'https:nowhere.com/custom-a12456' })  
 ```
 
 
-###### Preloading routes via Router options
+###### EXAMPLE 2: Preloading routes via Router options
 ```js
 import { Router } from 'itty-router'
 
 // let's define a simple request handler
 const handler = request => request.params
 
-// and load the route while
+// and load the route while creating the router
 const router = Router({
   routes: [
     [ 'GET', /^\/custom-(?<id>\w\d{3})$/, [handler] ], // same example as above, but shortened
   ]
 })
 
+// add routes normally...
 router.get('/test', () => new Response('You can still define routes normally as well...'))
 
 // router will catch on custom route, as expected

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
   <img alt="Join the discussion on Github" src="https://img.shields.io/badge/Github%20Discussions%20%26%20Support-Chat%20now!-blue" />
 </a>-->
 
-It's an itty bitty router, designed for Express.js-like routing within [Cloudflare Workers](https://developers.cloudflare.com/workers/) (or anywhere else). Like... it's super tiny (~460 bytes), with zero dependencies. For reals.
+It's an itty bitty router, designed for Express.js-like routing within [Cloudflare Workers](https://developers.cloudflare.com/workers/) (or anywhere else). Like... it's super tiny ([~4xx bytes](https://bundlephobia.com/package/itty-router)), with zero dependencies. For reals.
 
 For quality-of-life improvements (e.g. middleware, cookies, body parsing, json handling, errors, and an itty version with automatic exception handling), to further shorten your routing code, be sure to check out [itty-router-extras](https://www.npmjs.com/package/itty-router-extras) - also specifically written for API development on [Cloudflare Workers](https://developers.cloudflare.com/workers/)!
 
 ## Features
-- [x] Tiny (~4xx bytes compressed) with zero dependencies.
+- [x] Tiny ([~4xx bytes](https://bundlephobia.com/package/itty-router) compressed) with zero dependencies.
 - [x] Full sync/async support.  Use it when you need it!
 - [x] Route params, with wildcards and optionals (e.g. `/api/:collection/:id?`)
 - [x] Query parsing (e.g. `?page=3&foo=bar`)

--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ This trick allows methods (e.g. "get", "post") to by defined dynamically by the 
 These folks are the real heroes, making open source the powerhouse that it is!  Help out and get your name added to this list! <3
 
 #### Core, Concepts, and Codebase
+- [@taralx](https://github.com/taralx) - router internal code-golfing refactor for performance and character savings
 - [@hunterloftis](https://github.com/hunterloftis) - router.handle() method now accepts extra arguments and passed them to route functions
 - [@mvasigh](https://github.com/mvasigh) - proxy hacks courtesy of this chap
 #### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itty-router",
-  "version": "2.3.10-next.1",
+  "version": "2.3.10-next.2",
   "description": "Tiny, zero-dependency router with route param and query parsing - build for Cloudflare Workers, but works everywhere!",
   "main": "./dist/itty-router.min.js",
   "types": "./dist/itty-router.d.ts",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls",
     "prerelease": "yarn verify",
     "prebuild": "rimraf dist && mkdir dist && node prebuild.js && cp src/itty-router.d.ts dist",
-    "build": "terser -c -m toplevel -- dist/itty-router.js  > dist/itty-router.min.js",
+    "build": "uglifyjs dist/itty-router.js -c -m --toplevel > dist/itty-router.min.js",
     "postbuild": "node check-size.js",
     "release": "release --tag --push"
   },
@@ -67,7 +67,7 @@
     "isomorphic-fetch": "^3.0.0",
     "jest": "^27.0.3",
     "rimraf": "^3.0.2",
-    "terser": "^5.7.0",
+    "uglify-js": "^3.13.8",
     "vite": "^2.3.5",
     "yarn": "^1.22.10",
     "yarn-release": "^1.10.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itty-router",
-  "version": "2.3.10",
+  "version": "2.3.10-next.0",
   "description": "Tiny, zero-dependency router with route param and query parsing - build for Cloudflare Workers, but works everywhere!",
   "main": "./dist/itty-router.min.js",
   "types": "./dist/itty-router.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itty-router",
-  "version": "2.3.10-next.0",
+  "version": "2.3.10-next.1",
   "description": "Tiny, zero-dependency router with route param and query parsing - build for Cloudflare Workers, but works everywhere!",
   "main": "./dist/itty-router.min.js",
   "types": "./dist/itty-router.d.ts",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/itty-router.min.js",
   "types": "./dist/itty-router.d.ts",
   "files": [
-    "dist/itty-router.js",
     "dist/itty-router.min.js",
     "dist/itty-router.d.ts"
   ],

--- a/prebuild.js
+++ b/prebuild.js
@@ -2,18 +2,19 @@ const { readFileSync, writeFileSync } = require('fs-extra')
 
 const base = readFileSync('./src/itty-router.js', { encoding: 'utf-8' })
 const minifiedBase = base
-  .replace(/\bhandlers\b/g, 'hs') // Handler(S)
-  .replace(/\bhandler\b/g, 'h') // Handler
-  .replace(/([^\.])obj\b/g, '$1t') // Target
-  .replace(/([^\.])options\b/g, '$1o') // Options
-  .replace(/([^\.])receiver\b/g, '$1c') // Options
-  .replace(/([^\.])route\b/g, '$1p') // Path
-  .replace(/([^\.])\.routes\b/g, '$1\.r') // routes Queue
-  .replace(/args/g, 'a') // Args
-  .replace(/([^\.])request\b/g, '$1r') // Request
-  .replace(/([^\.])response\b/g, '$1s') // reSponse
+  .replace(/^\s*\/\/.*\n/mg, '') // remove comments
+  .replace(/\bargs\b/g, 'a') // Args
+  .replace(/\bhandlers\b/g, 'H') // (H)andlers
+  .replace(/\broutes([^:])/g, 'r$1') // Routes
+  .replace(/([^\.])handler\b/g, '$1h') // Handler
   .replace(/([^\.])match\b/g, '$1m') // Match
+  .replace(/([^\.])method\b/g, '$1M') // (M)ethod
   .replace(/([^\.])prop\b/g, '$1k') // Key
+  .replace(/([^\.])receiver\b/g, '$1c') // Options
+  .replace(/([^\.])request\b/g, '$1q') // reQuest
+  .replace(/([^\.])response\b/g, '$1s') // reSponse
+  .replace(/([^\.])route\b/g, '$1p') // Path
+  .replace(/([^\.])target\b/g, '$1t') // Target
   .replace(/([^\.])url\b/g, '$1u') // Url
 writeFileSync('./dist/itty-router.js', minifiedBase)
 console.log('minifying variables --> dist/itty-router.js')

--- a/src/itty-router.d.ts
+++ b/src/itty-router.d.ts
@@ -15,6 +15,12 @@ interface Request {
   url: string
   params?: Obj
   query?: Obj
+
+  arrayBuffer?(): Promise
+  blob?(): Promise
+  formData?(): Promise
+  json?(): Promise
+  text?(): Promise
 }
 
 type Router = {
@@ -25,6 +31,7 @@ type Router = {
 
 interface RouterOptions {
   base?: string
+  r?: any[]
 }
 
 export function Router(options?:RouterOptions): Router

--- a/src/itty-router.d.ts
+++ b/src/itty-router.d.ts
@@ -10,6 +10,12 @@ export interface Route {
   <TRequest>(path: string, ...handlers: RouteHandler<TRequest & Request>[]): Router
 }
 
+export interface RouteEntry<Array> {
+  0: string
+  1: RegExp
+  2: RouteHandler[]
+}
+
 export interface Request {
   method?: string
   params?: Obj

--- a/src/itty-router.d.ts
+++ b/src/itty-router.d.ts
@@ -1,20 +1,20 @@
-interface RouteHandler<TRequest> {
-  (request: TRequest & Request, ...args: any): any
-}
-
-interface Route {
-  <TRequest>(path: string, ...handlers: RouteHandler<TRequest & Request>[]): Router
-}
-
-type Obj = {
+export type Obj = {
   [propName: string]: string
 }
 
-interface Request {
+export interface RouteHandler<TRequest> {
+  (request: TRequest & Request, ...args: any): any
+}
+
+export interface Route {
+  <TRequest>(path: string, ...handlers: RouteHandler<TRequest & Request>[]): Router
+}
+
+export interface Request {
   method?: string
-  url: string
   params?: Obj
   query?: Obj
+  url: string
 
   arrayBuffer?(): Promise
   blob?(): Promise
@@ -23,13 +23,13 @@ interface Request {
   text?(): Promise
 }
 
-type Router = {
+export type Router = {
   handle: (request: Request, ...extra: any) => any
 } & {
   [any:string]: Route
 }
 
-interface RouterOptions {
+export interface RouterOptions {
   base?: string
   r?: any[]
 }

--- a/src/itty-router.js
+++ b/src/itty-router.js
@@ -1,4 +1,4 @@
-const Router = ({ base = '', routes = [] } = {}) => ({
+const Router = ({ base = '', r = [] } = {}) => ({
   __proto__: new Proxy({}, {
     get: (target, prop, receiver) => (route, ...handlers) =>
       r.push([
@@ -13,7 +13,7 @@ const Router = ({ base = '', routes = [] } = {}) => ({
       ]) && receiver
   }),
   // eslint-disable-next-line object-shorthand
-  routes,
+  r,
   async handle (request, ...args) {
     let response, match,
         url = new URL(request.url)

--- a/src/itty-router.js
+++ b/src/itty-router.js
@@ -1,7 +1,7 @@
-const Router = ({ base = '', routes = [] } = {}) => ({
+const Router = ({ base = '', r = [] } = {}) => ({
   __proto__: new Proxy({}, {
     get: (target, prop, receiver) => (route, ...handlers) =>
-      routes.push([
+      r.push([
         RegExp(`^${(base + route)
           .replace(/(\/?)\*/g, '($1.*)?')
           .replace(/\/$/, '')
@@ -13,12 +13,12 @@ const Router = ({ base = '', routes = [] } = {}) => ({
       ]) && receiver
   }),
   // eslint-disable-next-line object-shorthand
-  routes,
+  r,
   async handle (request, ...args) {
     let response, match,
         url = new URL(request.url)
     request.query = Object.fromEntries(url.searchParams)
-    for (let [route, handlers, method] of routes) {
+    for (let [route, handlers, method] of r) {
       if ((method === request.method || method === 'ALL') && (match = url.pathname.match(route))) {
         request.params = match.groups
         for (let handler of handlers) {

--- a/src/itty-router.js
+++ b/src/itty-router.js
@@ -2,6 +2,7 @@ const Router = ({ base = '', routes = [] } = {}) => ({
   __proto__: new Proxy({}, {
     get: (target, prop, receiver) => (route, ...handlers) =>
       routes.push([
+        prop.toUpperCase(),
         RegExp(`^${(base + route)
           .replace(/(\/?)\*/g, '($1.*)?')
           .replace(/\/$/, '')
@@ -9,7 +10,6 @@ const Router = ({ base = '', routes = [] } = {}) => ({
           .replace(/\.(?=[\w(])/, '\\.')
         }/*$`),
         handlers,
-        prop.toUpperCase(),
       ]) && receiver
   }),
   // eslint-disable-next-line object-shorthand
@@ -18,7 +18,7 @@ const Router = ({ base = '', routes = [] } = {}) => ({
     let response, match,
         url = new URL(request.url)
     request.query = Object.fromEntries(url.searchParams)
-    for (let [route, handlers, method] of routes) {
+    for (let [method, route, handlers] of routes) {
       if ((method === request.method || method === 'ALL') && (match = url.pathname.match(route))) {
         request.params = match.groups
         for (let handler of handlers) {

--- a/src/itty-router.js
+++ b/src/itty-router.js
@@ -1,7 +1,7 @@
-const Router = ({ base = '', r = [] } = {}) => ({
+const Router = ({ base = '', routes = [] } = {}) => ({
   __proto__: new Proxy({}, {
     get: (target, prop, receiver) => (route, ...handlers) =>
-      r.push([
+      routes.push([
         RegExp(`^${(base + route)
           .replace(/(\/?)\*/g, '($1.*)?')
           .replace(/\/$/, '')
@@ -13,12 +13,12 @@ const Router = ({ base = '', r = [] } = {}) => ({
       ]) && receiver
   }),
   // eslint-disable-next-line object-shorthand
-  r,
+  routes,
   async handle (request, ...args) {
     let response, match,
         url = new URL(request.url)
     request.query = Object.fromEntries(url.searchParams)
-    for (let [route, handlers, method] of r) {
+    for (let [route, handlers, method] of routes) {
       if ((method === request.method || method === 'ALL') && (match = url.pathname.match(route))) {
         request.params = match.groups
         for (let handler of handlers) {

--- a/src/itty-router.js
+++ b/src/itty-router.js
@@ -1,30 +1,32 @@
-const Router = (options = {}) =>
-  new Proxy(options, {
-    get: (obj, prop, receiver) => prop === 'handle'
-      ? async (request, ...args) => {
-          for (let [route, handlers] of obj.routes.filter(i => i[2] === request.method || i[2] === 'ALL')) {
-            let match, response, url
-            if (match = (url = new URL(request.url)).pathname.match(route)) {
-              request.params = match.groups
-              request.query = request.query || Object.fromEntries(url.searchParams.entries())
-
-              for (let handler of handlers) {
-                if ((response = await handler(request.proxy || request, ...args)) !== undefined) return response
-              }
-            }
-          }
+const Router = ({ base = '' } = {}, routes = []) => ({
+  __proto__: new Proxy({}, {
+    get: (target, prop, receiver) => (route, ...handlers) =>
+      routes.push([
+        RegExp(`^${(base + route)
+          .replace(/(\/?)\*/g, '($1.*)?')
+          .replace(/\/$/, '')
+          .replace(/:(\w+|\()(\?)?(\.)?/g, '$2(?<$1>[^/$3]+)$2$3')
+          .replace(/\.(?=[\w(])/, '\\.')
+        }/*$`),
+        handlers,
+        prop.toUpperCase(),
+      ]) && receiver
+  }),
+  // eslint-disable-next-line object-shorthand
+  routes: routes,
+  async handle (request, ...args) {
+    let response, match,
+        url = new URL(request.url)
+    request.query = Object.fromEntries(url.searchParams)
+    for (let [route, handlers, method] of routes) {
+      if ((method === request.method || method === 'ALL') && (match = url.pathname.match(route))) {
+        request.params = match.groups
+        for (let handler of handlers) {
+          if ((response = await handler(request.proxy || request, ...args)) !== undefined) return response
         }
-      : (route, ...handlers) =>
-          (obj.routes = obj.routes || []).push([
-            `^${((obj.base || '') + route)
-              .replace(/(\/?)\*/g, '($1.*)?')
-              .replace(/\/$/, '')
-              .replace(/:(\w+|\()(\?)?(\.)?/g, '$2(?<$1>[^/$3]+)$2$3')
-              .replace(/\.(?=[\w(])/, '\\.')
-            }\/*$`,
-            handlers,
-            prop.toUpperCase(),
-          ]) && receiver
-  })
+      }
+    }
+  }
+})
 
 module.exports = { Router }

--- a/src/itty-router.js
+++ b/src/itty-router.js
@@ -1,24 +1,25 @@
-const Router = ({ base = '' } = {}, routes = []) => ({
+const Router = ({ base = '', r = [] } = {}) => ({
   __proto__: new Proxy({}, {
     get: (target, prop, receiver) => (route, ...handlers) =>
-      routes.push([
+      r.push([
         RegExp(`^${(base + route)
           .replace(/(\/?)\*/g, '($1.*)?')
           .replace(/\/$/, '')
-          .replace(/:(\w+|\()(\?)?(\.)?/g, '$2(?<$1>[^/$3]+)$2$3')
+          .replace(/:(\w+)(\?)?(\.)?/g, '$2(?<$1>[^/]+)$2$3')
           .replace(/\.(?=[\w(])/, '\\.')
+          // .replace(/\.\?\(/, '(?:\\.)(')
         }/*$`),
         handlers,
         prop.toUpperCase(),
       ]) && receiver
   }),
   // eslint-disable-next-line object-shorthand
-  routes: routes,
+  r,
   async handle (request, ...args) {
     let response, match,
         url = new URL(request.url)
     request.query = Object.fromEntries(url.searchParams)
-    for (let [route, handlers, method] of routes) {
+    for (let [route, handlers, method] of r) {
       if ((method === request.method || method === 'ALL') && (match = url.pathname.match(route))) {
         request.params = match.groups
         for (let handler of handlers) {

--- a/src/itty-router.spec.js
+++ b/src/itty-router.spec.js
@@ -38,7 +38,7 @@ describe('Router', () => {
 
   it('allows introspection', () => {
     const r = []
-    const config = { r }
+    const config = { routes: r }
     const router = Router(config)
 
     router
@@ -47,7 +47,7 @@ describe('Router', () => {
       .post('/baz', () => {})
 
     expect(r.length).toBe(3) // can pass in the routes directly through "r"
-    expect(config.r.length).toBe(3) // or just look at the mututated config
+    expect(config.routes.length).toBe(3) // or just look at the mututated config
   })
 
   describe('.{method}(route: string, handler1: function, ..., handlerN: function)', () => {

--- a/src/itty-router.spec.js
+++ b/src/itty-router.spec.js
@@ -38,7 +38,7 @@ describe('Router', () => {
 
   it('allows introspection', () => {
     const r = []
-    const config = { routes: r }
+    const config = { r }
     const router = Router(config)
 
     router
@@ -47,7 +47,7 @@ describe('Router', () => {
       .post('/baz', () => {})
 
     expect(r.length).toBe(3) // can pass in the routes directly through "r"
-    expect(config.routes.length).toBe(3) // or just look at the mututated config
+    expect(config.r.length).toBe(3) // or just look at the mututated config
   })
 
   describe('.{method}(route: string, handler1: function, ..., handlerN: function)', () => {

--- a/src/itty-router.spec.js
+++ b/src/itty-router.spec.js
@@ -54,10 +54,11 @@ describe('Router', () => {
   it('allows preloading advanced routes', async () => {
     const basicHandler = jest.fn(req => req.params)
     const customHandler = jest.fn(req => req.params)
+    const customHandler2 = jest.fn(req => req.params)
     const router = Router({
                     routes: [
-                      [ /^\/test\.(?<x>[^/]+)\/*$/, [basicHandler], 'GET' ],
-                      [ /^\/custom-(?<custom>\d{2,4})$/, [customHandler], 'GET' ],
+                      [ 'GET', /^\/test\.(?<x>[^/]+)\/*$/, [basicHandler] ],
+                      [ 'GET', /^\/custom-(?<custom>\d{2,4})$/, [customHandler] ],
                     ]
                   })
 
@@ -69,6 +70,10 @@ describe('Router', () => {
 
     await router.handle(buildRequest({ path: '/custom-123' }))
     expect(customHandler).toHaveReturnedWith({ custom: '123' }) // custom route hit
+
+    router.routes.push([ 'GET', /^\/custom2-(?<custom>\w\d{3})$/, [customHandler2] ])
+    await router.handle(buildRequest({ path: '/custom2-a456' }))
+    expect(customHandler2).toHaveReturnedWith({ custom: 'a456' }) // custom route hit
   })
 
   describe('.{method}(route: string, handler1: function, ..., handlerN: function)', () => {

--- a/src/itty-router.spec.js
+++ b/src/itty-router.spec.js
@@ -36,6 +36,20 @@ describe('Router', () => {
     expect(typeof Router).toBe('function')
   })
 
+  it('allows introspection', () => {
+    const r = []
+    const config = { r }
+    const router = Router(config)
+
+    router
+      .get('/foo', () => {})
+      .patch('/bar', () => {})
+      .post('/baz', () => {})
+
+    expect(r.length).toBe(3) // can pass in the routes directly through "r"
+    expect(config.r.length).toBe(3) // or just look at the mututated config
+  })
+
   describe('.{method}(route: string, handler1: function, ..., handlerN: function)', () => {
     it('can accept multiple handlers (each mutates request)', async () => {
       const r = Router()
@@ -381,8 +395,10 @@ describe('Router', () => {
       testRoutes([
         { route: '/:id.:format', path: '/foo', returns: false },
         { route: '/:id.:format', path: '/foo.jpg', returns: { id: 'foo', format: 'jpg' } },
+        { route: '/:id.:format', path: '/foo.bar.jpg', returns: { id: 'foo.bar', format: 'jpg' } },
         { route: '/:id.:format?', path: '/foo', returns: { id: 'foo' } },
-        { route: '/:id.:format?', path: '/foo.jpg', returns: { id: 'foo', format: 'jpg' } },
+        // { route: '/:id.:format?', path: '/foo.bar.jpg', returns: { id: 'foo.bar', format: 'jpg' }, log: true }, // FAILING TEST - known bug
+        // { route: '/:id.:format?', path: '/foo.jpg', returns: { id: 'foo', format: 'jpg' }, log: true }, // FAILING TEST - known bug
         { route: '/:id.:format?', path: '/foo', returns: { id: 'foo' } },
       ])
     })
@@ -409,6 +425,22 @@ describe('Router', () => {
         { route: '/foo?', path: '/fooo', returns: false },
         { route: '/\.', path: '/f' },
         { route: '/\.', path: '/', returns: false },
+
+        { route: '/x|y', path: '/y', returns: true },
+        { route: '/x|y', path: '/x', returns: true },
+        { route: '/x/y|z', path: '/z', returns: true }, // should require second path as y or z
+        { route: '/x/y|z', path: '/x/y', returns: true }, // shouldn't allow the weird pipe
+        { route: '/x/y|z', path: '/x/z', returns: true }, // shouldn't allow the weird pipe
+        { route: '/xy*', path: '/x', returns: false },
+        { route: '/xy*', path: '/xyz', returns: true },
+        { route: '/:x.y', path: '/a.x.y', returns: { x: 'a.x' } },
+        { route: '/x.y', path: '/xay', returns: false }, // dots are enforced as dots, not any character (e.g. extensions)
+        { route: '/xy{2}', path: '/xyxy', returns: false }, // no regex repeating supported
+        { route: '/xy{2}', path: '/xy/xy', returns: false }, // no regex repeating supported
+        { route: '/:x.:y', path: '/a.b.c', returns: { x: 'a.b', y: 'c' } }, // standard file + extension format
+        { route: '/test.:x', path: '/test.a.b', returns: { x: 'a.b' } }, // dots are still captured as part of the param
+        { route: '/:x?.y', path: '/test.y', returns: { x: 'test' } },
+        { route: '/x/:y*', path: '/x/test', returns: { y: 'test' } },
       ])
     })
 

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -16,15 +16,15 @@ const testRoute = async ({
   returns = true,
   log = false,
 }, Router) => {
-  const c = {}
-  const router = Router(c)
+  const r = []
+  const router = Router({ r })
   const handler = jest.fn(req => req.params)
 
   // register route
   router[method](route, handler)
 
   log && console.log({
-    regex: c.routes,
+    routes: r,
     route,
     path,
   })

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -16,15 +16,15 @@ const testRoute = async ({
   returns = true,
   log = false,
 }, Router) => {
-  const r = []
-  const router = Router({ r })
+  const routes = []
+  const router = Router({ routes })
   const handler = jest.fn(req => req.params)
 
   // register route
   router[method](route, handler)
 
   log && console.log({
-    routes: r,
+    routes,
     route,
     path,
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1421,11 +1421,6 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
 commander@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
@@ -3666,14 +3661,6 @@ source-map-support@^0.5.6:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@~0.5.19:
-  version "0.5.19"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
-  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
 source-map@^0.5.0:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
@@ -3684,7 +3671,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3, source-map@~0.7.2:
+source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -3823,15 +3810,6 @@ terminal-link@^2.0.0:
   dependencies:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
-
-terser@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.7.0.tgz#a761eeec206bc87b605ab13029876ead938ae693"
-  integrity sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==
-  dependencies:
-    commander "^2.20.0"
-    source-map "~0.7.2"
-    source-map-support "~0.5.19"
 
 test-exclude@^6.0.0:
   version "6.0.0"
@@ -3974,6 +3952,11 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+uglify-js@^3.13.8:
+  version "3.13.8"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.8.tgz#7c2f9f2553f611f3ff592bdc19c6fb208dc60afb"
+  integrity sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==
 
 uniq@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
# Notable Changes
- preserve existing signature (no second param) to matching any existing introspection schemes - maybe cost a few characters, but it's a bit more future-proof/robust to potential future options we add.
- Router `options` are now:
  - `base?: string` - optional base path
  - `routes?: any[]` - optional array of routes (for introspection or preloading with advanced regex)
  - unrelated: adds a bit of added interface for the internal `Request` definition to address #47 
  - unrelated: export TS interfaces to address #38 
  - thanks to the @taralx refactor, we can now support preloading routes, which means those rare edge cases of crazy regex (previously not possible) requirements, can now be force-fed into the router (at config stage, or even after... also thanks to the more exposed `router.routes` array.  Pretty sick!
  
#### Example of manual loading routes:
```js
// EXAMPLE 1 mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm
it('allows preloading advanced routes', async () => {
  const basicHandler = jest.fn(req => req.params)
  const customHandler = jest.fn(req => req.params)

  const router = Router({
                  routes: [
                    [ 'GET', /^\/test\.(?<x>[^/]+)\/*$/, [basicHandler] ],
                    [ 'GET', /^\/custom-(?<custom>\d{2,4})$/, [customHandler] ], // match 2 to 4 digits only
                  ]
                })

  await router.handle(buildRequest({ path: '/test.a.b' }))
  expect(basicHandler).toHaveReturnedWith({ x: 'a.b' })

  await router.handle(buildRequest({ path: '/custom-12345' }))
  expect(customHandler).not.toHaveBeenCalled() // custom route mismatch

  await router.handle(buildRequest({ path: '/custom-123' }))
  expect(customHandler).toHaveReturnedWith({ custom: '123' }) // custom route hit
})


// EXAMPLE 2 mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm
it('allows loading advanced routes after config', async () => {
  const handler = jest.fn(req => req.params)

  const router = Router()

  // allows manual loading (after config)
  router.routes.push([ 'GET', /^\/custom2-(?<custom>\w\d{3})$/, [handler] ])

  await router.handle(buildRequest({ path: '/custom2-a456' }))
  expect(handler).toHaveReturnedWith({ custom: 'a456' }) // custom route hit
})
```
  
**DISCUSSION:** If we change `r` to `routes`, and prevent the prebuild.js from mangling it, the filesize does grow (405b --> 409b), but so does the legibility around this weird introspection.  Thoughts?  I'm all for absolute minimum filesize, but... legibility.  Torn.  Don't think we would have to count the decision on this one as a breaking change (if we opt for "routes"), because the existing pattern isn't documented, and is hopefully only used in debugging patterns at most.  Regardless of the path chosen here, documentation will be added to disclose this functionality.

**UPDATE:** *unless there's strong objection, I'm opting for readability over ultimate filesize... `router.routes` it is*

# Filesize Comparison (pretty sure this includes the type declaration, so appears artificially inflated a bit)
- **current:** https://bundlephobia.com/package/itty-router@2.3.10 
- **@next ("routes"):** https://bundlephobia.com/package/itty-router@2.3.10-next.0
- **@next ("r"):** https://bundlephobia.com/package/itty-router@2.3.10-next.1