### PR TITLE
feat: add support for greedy params

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": false
-}

--- a/src/itty-router.js
+++ b/src/itty-router.js
@@ -6,6 +6,7 @@ const Router = ({ base = '', routes = [] } = {}) => ({
         RegExp(`^${(base + route)
           .replace(/(\/?)\*/g, '($1.*)?')
           .replace(/\/$/, '')
+          .replace(/(:(\w+)\+)/, '(?<$2>.*)')
           .replace(/:(\w+)(\?)?(\.)?/g, '$2(?<$1>[^/]+)$2$3')
           .replace(/\.(?=[\w(])/, '\\.')
         }/*$`),

--- a/src/itty-router.spec.js
+++ b/src/itty-router.spec.js
@@ -476,6 +476,7 @@ it('allows loading advanced routes after config', async () => {
         { route: '/test.:x', path: '/test.a.b', returns: { x: 'a.b' } }, // dots are still captured as part of the param
         { route: '/:x?.y', path: '/test.y', returns: { x: 'test' } },
         { route: '/x/:y*', path: '/x/test', returns: { y: 'test' } },
+        { route: '/x/:y+', path: '/x/test/test', returns: { y: 'test/test' } },
       ])
     })
 


### PR DESCRIPTION
Hi,

Thanks for this awesome router for cloudflare :)

The only feature I was missing was the support for greedy params, which I find pretty useful when doing things like proxying. So, for instance if I want to fetch static files from S3 on subpath you could use a path like `/static/:file+` as path and that would pass everything after static in the file param.

There doesn't seem to be a real standard for this across different routers, so maybe there's a better way of doing it? Anyway.. this PR makes it possible to do the routing like the example above.

Cheers!