### PR TITLE
Default to the router request type in each Route

### DIFF
--- a/src/itty-router.d.ts
+++ b/src/itty-router.d.ts
@@ -29,16 +29,16 @@ export interface Request {
   text?(): Promise<any>
 }
 
-export interface IHTTPMethods<TRequest = Request, TMethods = {}> {
-  get: Route<TRequest, TMethods>
-  head: Route<TRequest, TMethods>
-  post: Route<TRequest, TMethods>
-  put: Route<TRequest, TMethods>
-  delete: Route<TRequest, TMethods>
-  connect: Route<TRequest, TMethods>
-  options: Route<TRequest, TMethods>
-  trace: Route<TRequest, TMethods>
-  patch: Route<TRequest, TMethods>
+export interface IHTTPMethods<TRequest = Request> {
+  get: Route<TRequest, IHTTPMethods>
+  head: Route<TRequest, IHTTPMethods>
+  post: Route<TRequest, IHTTPMethods>
+  put: Route<TRequest, IHTTPMethods>
+  delete: Route<TRequest, IHTTPMethods>
+  connect: Route<TRequest, IHTTPMethods>
+  options: Route<TRequest, IHTTPMethods>
+  trace: Route<TRequest, IHTTPMethods>
+  patch: Route<TRequest, IHTTPMethods>
 }
 
 export type Router<TRequest = Request, TMethods = {}> = {

--- a/src/itty-router.d.ts
+++ b/src/itty-router.d.ts
@@ -6,8 +6,8 @@ export interface RouteHandler<TRequest> {
   (request: TRequest, ...args: any): any
 }
 
-export interface Route {
-  <TRequest>(path: string, ...handlers: RouteHandler<TRequest & Request>[]): Router<TRequest>
+export interface Route<TRequest = Request> {
+  <RRequest>(path: string, ...handlers: RouteHandler<RRequest & TRequest & Request>[]): Router<TRequest>
 }
 
 export interface RouteEntry<TRequest> {
@@ -29,24 +29,24 @@ export interface Request {
   text?(): Promise<any>
 }
 
-export interface IHTTPMethods {
-  get: Route
-  head: Route
-  post: Route
-  put: Route
-  delete: Route
-  connect: Route
-  options: Route
-  trace: Route
-  patch: Route
+export interface IHTTPMethods<TRequest = Request> {
+  get: Route<TRequest>
+  head: Route<TRequest>
+  post: Route<TRequest>
+  put: Route<TRequest>
+  delete: Route<TRequest>
+  connect: Route<TRequest>
+  options: Route<TRequest>
+  trace: Route<TRequest>
+  patch: Route<TRequest>
 }
 
 export type Router<TRequest = Request, TMethods = {}> = {
   handle: (request: TRequest, ...extra: any) => Promise<any>
   routes: RouteEntry<TRequest>[]
-  all: Route
+  all: Route<TRequest>
 } & TMethods & {
-  [any:string]: Route
+  [any:string]: Route<TRequest>
 }
 
 export interface RouterOptions<TRequest> {

--- a/src/itty-router.d.ts
+++ b/src/itty-router.d.ts
@@ -6,8 +6,8 @@ export interface RouteHandler<TRequest> {
   (request: TRequest, ...args: any): any
 }
 
-export interface Route<TRequest = Request> {
-  <RRequest>(path: string, ...handlers: RouteHandler<RRequest & TRequest & Request>[]): Router<TRequest>
+export interface Route<TRequest = Request, TMethods = {}> {
+  <RRequest>(path: string, ...handlers: RouteHandler<RRequest & TRequest & Request>[]): Router<TRequest, TMethods>
 }
 
 export interface RouteEntry<TRequest> {
@@ -29,24 +29,24 @@ export interface Request {
   text?(): Promise<any>
 }
 
-export interface IHTTPMethods<TRequest = Request> {
-  get: Route<TRequest>
-  head: Route<TRequest>
-  post: Route<TRequest>
-  put: Route<TRequest>
-  delete: Route<TRequest>
-  connect: Route<TRequest>
-  options: Route<TRequest>
-  trace: Route<TRequest>
-  patch: Route<TRequest>
+export interface IHTTPMethods<TRequest = Request, TMethods = {}> {
+  get: Route<TRequest, TMethods>
+  head: Route<TRequest, TMethods>
+  post: Route<TRequest, TMethods>
+  put: Route<TRequest, TMethods>
+  delete: Route<TRequest, TMethods>
+  connect: Route<TRequest, TMethods>
+  options: Route<TRequest, TMethods>
+  trace: Route<TRequest, TMethods>
+  patch: Route<TRequest, TMethods>
 }
 
 export type Router<TRequest = Request, TMethods = {}> = {
   handle: (request: TRequest, ...extra: any) => Promise<any>
   routes: RouteEntry<TRequest>[]
-  all: Route<TRequest>
+  all: Route<TRequest, TMethods>
 } & TMethods & {
-  [any:string]: Route<TRequest>
+  [any:string]: Route<TRequest, TMethods>
 }
 
 export interface RouterOptions<TRequest> {


### PR DESCRIPTION
Currently, if we have a custom request object (such as one with an optional user on it, or with params) we must prefix each route like this:

```ts
router.get<MyCustomRequest>('/endpoint, req => {
  console.log(req.user);
});

// or

router.get('/endpoint, (req: MyCustomRequest) => {
  console.log(req.user);
});
```

This change will allow routes to be typed to the request (while still allowing individual routes to still add another type):

```ts
interface MyCustomRequest extends Request {
  user?: User;
}

interface MyExtraCustomRequest extends MyCustomRequest {
  authed: boolean;
}

const router = Router<MyCustomRequest>();

router.get('/endpoint', req => {
  console.log(req.user);
});

router.get<MyExtraCustomRequest>('/secure/endpoint', req => {
  console.log(req.authed);
});
```