### PR TITLE
types: Use Request from TS built-in types

### DIFF
--- a/src/itty-router.d.ts
+++ b/src/itty-router.d.ts
@@ -1,3 +1,5 @@
+/// <reference lib="dom" />
+
 export type Obj = {
   [propName: string]: string
 }
@@ -14,19 +16,6 @@ export interface RouteEntry<TRequest> {
   0: string
   1: RegExp
   2: RouteHandler<TRequest>[]
-}
-
-export interface Request {
-  method: string
-  params?: Obj
-  query?: Obj
-  url: string
-
-  arrayBuffer?(): Promise<any>
-  blob?(): Promise<any>
-  formData?(): Promise<any>
-  json?(): Promise<any>
-  text?(): Promise<any>
 }
 
 export interface IHTTPMethods {

--- a/src/itty-router.d.ts
+++ b/src/itty-router.d.ts
@@ -9,7 +9,7 @@ export interface RouteHandler<TRequest> {
 }
 
 export interface Route {
-  <TRequest>(path: string, ...handlers: RouteHandler<TRequest & Request>[]): Router<TRequest>
+  <TRequest>(path: string, ...handlers: RouteHandler<TRequest & IttyRequest>[]): Router<TRequest>
 }
 
 export interface RouteEntry<TRequest> {
@@ -30,7 +30,17 @@ export interface IHTTPMethods {
   patch: Route
 }
 
-export type Router<TRequest = Request, TMethods = {}> = {
+interface IttyRequest extends Request {
+  params?: {
+    [key: string]: string
+  }
+  proxy?: object
+  query?: {
+    [k: string]: string | undefined
+  }
+}
+
+export type Router<TRequest = IttyRequest, TMethods = {}> = {
   handle: (request: TRequest, ...extra: any) => Promise<any>
   routes: RouteEntry<TRequest>[]
   all: Route
@@ -43,4 +53,4 @@ export interface RouterOptions<TRequest> {
   routes?: RouteEntry<TRequest>[]
 }
 
-export function Router<TRequest = Request, TMethods = {}>(options?:RouterOptions<TRequest>): Router<TRequest, TMethods>
+export function Router<TRequest = IttyRequest, TMethods = {}>(options?:RouterOptions<TRequest>): Router<TRequest, TMethods>


### PR DESCRIPTION
This PR replace the written `Request` with `Request` from TypeScript lib [dom](https://github.com/microsoft/TypeScript/blob/main/lib/lib.dom.d.ts).

## Why the triple-slashes?

> For declaration file authors who rely on built-in types, e.g. DOM APIs or built-in JS run-time constructors like Symbol or Iterable, triple-slash-reference lib directives are recommended. ([source](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-lib-))

## Why the stock `Request` will work?

> The Request interface represents an HTTP request and is part of the Fetch API. ([source](https://developers.cloudflare.com/workers/runtime-apis/request/))

## To test the types...

[`@ovv/itty-router`](https://www.npmjs.com/package/@ovv/itty-router)

Related: #57