### PR TITLE
Added missing function for 404 handling example

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ GET /todos/jane?limit=2&page=1
 ### Nested Routers with 404 handling
 ```js
 // lets save a missing handler
-const missingHandler = new Response('Not found.', { status: 404 })
+const missingHandler = () => new Response('Not found.', { status: 404 })
 
 // create a parent router
 const parentRouter = Router({ base: '/api' })


### PR DESCRIPTION
Just a small documentation fix for the 404 example code. It was missing a wrapping function around the Response object to be returned. 