### PR TITLE
fix: Add types path to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "require": "./dist/itty-router.min.js",
-      "import": "./dist/itty-router.min.mjs"
+      "import": "./dist/itty-router.min.mjs",
+      "types": "./dist/itty-router.d.ts"
     }
   },
   "types": "./dist/itty-router.d.ts",


### PR DESCRIPTION
In a ESM project using TypeScript, I am unable to import types correctly.

I have followed the suggestions recommended here, which have resolved the issue: https://stackoverflow.com/questions/72457791/typescript-packages-that-ship-with-mjs-and-d-ts-but-without-d-mts-how-to-i
