### PR TITLE
fix: TypeScript definitions in package.json/exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
   "main": "./dist/itty-router.min.js",
   "exports": {
     ".": {
-      "require": "./dist/itty-router.min.js",
+      "types": "./dist/itty-router.d.ts",
       "import": "./dist/itty-router.min.mjs",
-      "types": "./dist/itty-router.d.ts"
+      "require": "./dist/itty-router.min.js",
+      "default": "./dist/itty-router.min.mjs"
     }
   },
   "types": "./dist/itty-router.d.ts",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/197134/183302044-65419a14-2802-4e3e-a97b-bf0216f53fe4.png)

#### Fixes `package.json/exports`

- `"types"` - can be used by typing systems to resolve the typing file for the given export. This condition should always be included first.
- `"default"` - the generic fallback that always matches. Can be a CommonJS or ES module file. This condition should always come last.

#### Reference

- https://nodejs.org/api/packages.html

Ref #114 