### PR TITLE
fix: Make RouterHints non-optional

### DIFF
--- a/src/itty-router.ts
+++ b/src/itty-router.ts
@@ -30,13 +30,13 @@ export type Route = <T extends RouterType>(
 ) => T
 
 export type RouterHints = {
-  all?: Route,
-  delete?: Route,
-  get?: Route,
-  options?: Route,
-  patch?: Route,
-  post?: Route,
-  put?: Route,
+  all: Route,
+  delete: Route,
+  get: Route,
+  options: Route,
+  patch: Route,
+  post: Route,
+  put: Route,
 }
 
 export type RouterType = {
@@ -54,6 +54,7 @@ const toQuery = (params: any) =>
     ) && acc || acc, {})
 
 export const Router = ({ base = '', routes = [] }: RouterOptions = {}): RouterType =>
+  // @ts-expect-error TypeScript doesn't know that Proxy makes this work
   ({
     __proto__: new Proxy({} as RouterType, {
       get: (target, prop: string, receiver) => (route: string, ...handlers: RouteHandler[]) =>


### PR DESCRIPTION
Optionality here was an unintended side effect of moving to script-mode TypeScript. Unfortunately, TS doesn't handle Proxies very well and thinks that these are undefined (which is technically true until the proxy is called.) TypeScript will hopefully make typing proxies better in the future: https://github.com/microsoft/TypeScript/issues/20846

Based on the tests, there is no change on the external interface caused by the `@ts-expect-error`, and the routes no longer show as `possibly undefined`
![image](https://user-images.githubusercontent.com/10719325/208733568-1e8c9d17-64d0-4298-9d28-aecb605f4175.png)