### PR TITLE
feat: Add custom request types

### DIFF
--- a/src/example.ts
+++ b/src/example.ts
@@ -2,7 +2,8 @@ import {
   Router,               // the router itself
   IRequest,             // lightweight/generic Request type
   RouterType,           // generic Router type
-  Route,                // generic Route type
+  Route,
+  RequestLike,                // generic Route type
 } from './itty-router'
 
 // declare a custom Router type with used methods
@@ -41,3 +42,16 @@ export default {
 addEventListener('fetch', (event: FetchEvent) => {
   event.respondWith(router.handle(event.request))
 })
+
+// Add custom properties to the Request type at the Router level
+type CustomRequest = {
+  foo: string
+}
+
+const router2 = Router<CustomRequest>()
+  // middleware to poppulate request.foo
+  .get('/foo', (request) => { request.foo = 'bar' })
+  // route handler that uses request.foo
+  .get('/foo', (request) => {
+    return new Response(request.foo)
+  })

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,13 +1,11 @@
 import {
   Router,               // the router itself
   IRequest,             // lightweight/generic Request type
-  RouterType,           // generic Router type
   Route,
-  RequestLike,                // generic Route type
 } from './itty-router'
 
-// declare a custom Router type with used methods
-interface CustomRouter extends RouterType {
+// declare a custom methods type to allow custom methods
+interface CustomMethods {
   puppy: Route,
 }
 
@@ -21,11 +19,11 @@ const withAuthors = (request: IRequest) => {
   request.authors = ['foo', 'bar']
 }
 
-const router = Router({ base: '/' })
+const router = Router<{}, CustomMethods>({ base: '/' })
 
 router
-  .all('*', () => {})
-  .get<CustomRouter>('/authors', withAuthors, (request: RequestWithAuthors) => {
+  .all('*', () => { })
+  .get('/authors', withAuthors, (request: RequestWithAuthors) => {
     return request.authors?.[0]
   })
   .puppy('/:name', (request) => {
@@ -44,14 +42,18 @@ addEventListener('fetch', (event: FetchEvent) => {
 })
 
 // Add custom properties to the Request type at the Router level
-type CustomRequest = {
+type customRequestProps = {
   foo: string
 }
 
-const router2 = Router<CustomRequest>()
+const router2 = Router<customRequestProps>()
   // middleware to poppulate request.foo
   .get('/foo', (request) => { request.foo = 'bar' })
   // route handler that uses request.foo
   .get('/foo', (request) => {
     return new Response(request.foo)
+  })
+  // Still able to use custom route-specific request properties
+  .get('/authors', withAuthors, (request: RequestWithAuthors) => {
+    return request.authors?.[0]
   })

--- a/src/example.ts
+++ b/src/example.ts
@@ -57,3 +57,16 @@ const router2 = Router<customRequestProps>()
   .get('/authors', withAuthors, (request: RequestWithAuthors) => {
     return request.authors?.[0]
   })
+
+// Use custom request props and custom methods
+type customMethods = {
+  puppy: Route<customRequestProps>
+}
+
+const router3 = Router<customRequestProps, customMethods>()
+  .get('/foo', (request) => {
+    return request.foo
+  })
+  .puppy('/:name', (request) => {
+    return request.foo
+  })

--- a/src/itty-router.ts
+++ b/src/itty-router.ts
@@ -30,7 +30,7 @@ export interface RouteHandler<RequestType> {
 
 export type RouteEntry<RequestType> = [string, RegExp, RouteHandler<RequestType>[]]
 
-export type Route<RequestType> = <T extends RouterType<RequestType>>(
+export type Route<RequestType = RequestLike> = <T extends RouterType<RequestType>>(
   path: string,
   ...handlers: RouteHandler<RequestType>[]
 ) => T
@@ -45,7 +45,7 @@ export type RouterHints<RequestType> = {
   put: Route<RequestType>,
 }
 
-export type RouterType<RequestType> = {
+export type RouterType<RequestType = RequestLike> = {
   __proto__: RouterType<RequestType>,
   routes: RouteEntry<RequestType>[],
   handle: (request: RequestLike & RequestType, ...extra: any) => Promise<any>


### PR DESCRIPTION
This allows strict typing of requests in handlers by passing a generic to the router.
[Added examples in the tests](https://github.com/kwhitley/itty-router/pull/136/files#diff-f7a4cd323edcfa7835d5eb7d7eb1825fc58b6a3a6b5526cbf42b76f032ade900R589)

Users should prefer to use this over taking advantage of GenericTraps that don't have type info

## Methodology
I started by adding a generic `RequestType` in `RouteHandler`, and then added the generic to everything that started getting TS errors because of this change. No functionality changes.