### PR TITLE
Golf the regex

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -520,6 +520,10 @@ describe('ROUTE MATCHING', () => {
       { route: '/:id.:format?', path: '/foo.bar.jpg', returns: { id: 'foo.bar', format: 'jpg' } },
       { route: '/:id.:format?', path: '/foo.jpg', returns: { id: 'foo', format: 'jpg' } },
       { route: '/:id.:format?', path: '/foo', returns: { id: 'foo' } },
+      { route: '/:id.:format.:compress', path: '/foo.gz', returns: false },
+      { route: '/:id.:format.:compress', path: '/foo.txt.gz', returns: { id: 'foo', format: 'txt', compress: 'gz' } },
+      { route: '/:id.:format.:compress?', path: '/foo.txt', returns: { id: 'foo', format: 'txt' } },
+      { route: '/:id.:format?.:compress', path: '/foo.gz', returns: { id: 'foo', compress: 'gz' } },
     ])
   })
 
@@ -539,6 +543,7 @@ describe('ROUTE MATCHING', () => {
       { route: '/foo(bar|baz)', path: '/foobar' },
       { route: '/foo(bar|baz)', path: '/foobaz' },
       { route: '/foo(bar|baz)', path: '/foo', returns: false },
+      { route: '/foo:bar?', path: '/foXbar', returns: false },
       { route: '/foo+', path: '/foo' },
       { route: '/foo+', path: '/fooooooo' },
       { route: '/foo?', path: '/foo' },
@@ -557,9 +562,8 @@ describe('ROUTE MATCHING', () => {
       { route: '/xy{2}', path: '/xyxy', returns: false }, // no regex repeating supported
       { route: '/xy{2}', path: '/xy/xy', returns: false }, // no regex repeating supported
       { route: '/:x.:y', path: '/a.b.c', returns: { x: 'a.b', y: 'c' } }, // standard file + extension format
-      // { route: '/test.:x', path: '/test.a.b', returns: { x: 'a.b' } }, // dots are still captured as part of the param (REMOVE)
-      // { route: '/test.:x', path: '/test.a.b', returns: false }, // extensions only capture a single dot (ADD)
-      { route: '/:test.:x', path: '/test.a.b', returns: { test: 'test.a', x: 'b' } }, // extensions only capture a single dot
+      { route: '/test.:x', path: '/test.a.b', returns: false }, // extensions only capture a single dot
+      { route: '/test.:x', path: '/test.a', returns: { x: 'a' } },
       { route: '/:x?.y', path: '/test.y', returns: { x: 'test' } },
     ])
   })

--- a/src/itty-router.ts
+++ b/src/itty-router.ts
@@ -59,11 +59,11 @@ export const Router = ({ base = '', routes = [] }: RouterOptions = {}): RouterTy
         routes.push([
           prop.toUpperCase(),
           RegExp(`^${(base + '/' + route)
-            .replace(/:(\w+)\+/, '(?<$1>*)')                          // greedy params
-            .replace(/(\/?\.?):(\w+)(\?)?/g, '($1(?<$2>[^$1/]+?))$3') // named params and image format
-            .replace(/\./g, '\\.')                                    // dot in path
-            .replace(/\/+(\/|$)/g, '$1')                              // remove multiple/trailing slash
-            .replace(/(\/?)\*/g, '($1.*)?')                           // wildcard
+            .replace(/\/+(\/|$)/g, '$1')                       // remove multiple/trailing slash
+            .replace(/(\/?\.?):(\w+)\+/g, '($1(?<$2>*))')      // greedy params
+            .replace(/(\/?\.?):(\w+)/g, '($1(?<$2>[^$1/]+?))') // named params and image format
+            .replace(/\./g, '\\.')                             // dot in path
+            .replace(/(\/?)\*/g, '($1.*)?')                    // wildcard
           }/*$`),
           handlers,
         ]) && receiver

--- a/src/itty-router.ts
+++ b/src/itty-router.ts
@@ -59,12 +59,11 @@ export const Router = ({ base = '', routes = [] }: RouterOptions = {}): RouterTy
         routes.push([
           prop.toUpperCase(),
           RegExp(`^${(base + route)
-            .replace(/(\/?)\*/g, '($1.*)?')                             // trailing wildcard
-            .replace(/(\/$)|((?<=\/)\/)/, '')                           // remove trailing slash or double slash from joins
-            .replace(/(:(\w+)\+)/, '(?<$2>.*)')                         // greedy params
-            .replace(/:(\w+)(\?)?(\.)?/g, '$2(?<$1>[^/]+)$2$3')         // named params
-            .replace(/\.(?=[\w(])/, '\\.')                              // dot in path
-            .replace(/\)\.\?\(([^\[]+)\[\^/g, '?)\\.?($1(?<=\\.)[^\\.') // optional image format
+            .replace(/:(\w+)\+/, '(?<$1>*)')                          // greedy params
+            .replace(/(\/?\.?):(\w+)(\?)?/g, '($1(?<$2>[^$1/]+?))$3') // named params and image format
+            .replace(/\./g, '\\.')                                    // dot in path
+            .replace(/\/+(\/|$)/g, '$1')                              // remove multiple/trailing slash
+            .replace(/(\/?)\*/g, '($1.*)?')                           // wildcard
           }/*$`),
           handlers,
         ]) && receiver

--- a/src/itty-router.ts
+++ b/src/itty-router.ts
@@ -58,7 +58,7 @@ export const Router = ({ base = '', routes = [] }: RouterOptions = {}): RouterTy
       get: (target, prop: string, receiver) => (route: string, ...handlers: RouteHandler[]) =>
         routes.push([
           prop.toUpperCase(),
-          RegExp(`^${(base + route)
+          RegExp(`^${(base + '/' + route)
             .replace(/:(\w+)\+/, '(?<$1>*)')                          // greedy params
             .replace(/(\/?\.?):(\w+)(\?)?/g, '($1(?<$2>[^$1/]+?))$3') // named params and image format
             .replace(/\./g, '\\.')                                    // dot in path


### PR DESCRIPTION
### Few tests fails:

> × route `/.` matches path `/f`

Is there any reason to not escape all dots? I can revert that if needed.

> × route `/test.:x` returns params `{ x: "a.b" }` from path `/test.a.b`

Now the format params can't contain dots.

> × route `/x/:y*` returns params `{ y: "test" }` from path `/x/test`

This is same as `/x/:y/*`, e.g. `/x/test`, `/x/test/something` => `{ y: "test" }`.
Route with base: `/:foo` and route: `*` should work fine.


### Fixes:
`/foo:bar?` matching `/foXbar` (`{ bar: "Xbar" }`)

Need to write test for this.