### PR TITLE
Add HEAD type

### DIFF
--- a/src/itty-router.ts
+++ b/src/itty-router.ts
@@ -43,6 +43,7 @@ export type RouterHints = {
   patch: Route,
   post: Route,
   put: Route,
+  head: Route,
 }
 
 export type RouterType = {


### PR DESCRIPTION
I was working with itty-router and tried adding a HEAD route when I was getting a type error, itty-router seemed to handle the request fine for me and based on this comment https://github.com/kwhitley/itty-router/issues/87#issuecomment-1034023188 . I believe it's just missing in the types