### PR TITLE
fixes #175 by allowing full options inclusion in status and fixing types in createResponse

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "@typescript-eslint/parser": "^5.60.0",
     "@vitejs/plugin-vue": "^4.2.3",
     "@vitest/coverage-c8": "^0.32.2",
+    "@vitest/coverage-v8": "^0.32.2",
     "@whatwg-node/server": "^0.8.12",
     "coveralls": "^3.1.1",
     "eslint": "^8.43.0",

--- a/src/createResponse.ts
+++ b/src/createResponse.ts
@@ -1,22 +1,18 @@
 export interface ResponseFormatter {
-  (body?: any, options?: object): Response
+  (body?: any, options?: ResponseInit): Response
 }
 
 export interface BodyTransformer {
   (body: any): string
 }
 
-type ResponseFormatterOptions = {
-  headers?: object
-} & ResponseInit
-
 export const createResponse =
   (
     format = 'text/plain; charset=utf-8',
     transform?: BodyTransformer
   ): ResponseFormatter =>
-  (body, options: ResponseFormatterOptions = {}) => {
-    const { headers = {}, ...rest } = options
+  (body, options?: ResponseInit) => {
+    const { headers = {}, ...rest } = options || {}
 
     if (body?.constructor.name === 'Response') return body
 

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,1 +1,2 @@
-export const status = (status: number) => new Response(null, { status })
+export const status = (status: number, options?: ResponseInit): Response =>
+  new Response(null, { ...options, status })

--- a/yarn.lock
+++ b/yarn.lock
@@ -756,6 +756,23 @@
     picocolors "^1.0.0"
     std-env "^3.3.2"
 
+"@vitest/coverage-v8@^0.32.2":
+  version "0.32.2"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-0.32.2.tgz#efb74efd47ccdea59874c700f93f8c30b5766ab9"
+  integrity sha512-/+V3nB3fyeuuSeKxCfi6XmWjDIxpky7AWSkGVfaMjAk7di8igBwRsThLjultwIZdTDH1RAxpjmCXEfSqsMFZOA==
+  dependencies:
+    "@ampproject/remapping" "^2.2.1"
+    "@bcoe/v8-coverage" "^0.2.3"
+    istanbul-lib-coverage "^3.2.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.1"
+    istanbul-reports "^3.1.5"
+    magic-string "^0.30.0"
+    picocolors "^1.0.0"
+    std-env "^3.3.2"
+    test-exclude "^6.0.0"
+    v8-to-istanbul "^9.1.0"
+
 "@vitest/expect@0.32.2":
   version "0.32.2"
   resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-0.32.2.tgz#8111f6ab1ff3b203efbe3a25e8bb2d160ce4b720"
@@ -2452,7 +2469,16 @@ istanbul-lib-report@^3.0.0:
     make-dir "^3.0.0"
     supports-color "^7.1.0"
 
-istanbul-reports@^3.1.4:
+istanbul-lib-source-maps@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz#895f3a709fcfba34c6de5a42939022f3e4358551"
+  integrity sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==
+  dependencies:
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+    source-map "^0.6.1"
+
+istanbul-reports@^3.1.4, istanbul-reports@^3.1.5:
   version "3.1.5"
   resolved "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz"
   integrity sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==
@@ -3480,7 +3506,7 @@ source-map-support@~0.5.20:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@^0.6.0:
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -3952,6 +3978,15 @@ v8-to-istanbul@^9.0.0:
   version "9.0.1"
   resolved "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz"
   integrity sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.12"
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^1.6.0"
+
+v8-to-istanbul@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz#1b83ed4e397f58c85c266a570fc2558b5feb9265"
+  integrity sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"


### PR DESCRIPTION
### Description

1. New signature for `status` takes full `ResponseInit` options as second param:

    ```ts
    status = (status: number, options?: ResponseInit): Response
    ```

1. Changed `ResponseFormatter` internal type for `createResponse` to be more helpful in downstream uses (e.g. `json`)

    ```ts
    interface ResponseFormatter {
      (body?: any, options?: ResponseInit): Response
    }
    ```

### Issue Related

See #175 

### TODO
- [ ] add documentation to itty.dev