### PR TITLE
Fix special characters in request params

### DIFF
--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -409,6 +409,15 @@ describe('Router', () => {
         router.get('/foo', vi.fn()).get('/foo', vi.fn())
       }).not.toThrow()
     })
+
+    it('allows special characters in params', async () => {
+      const specialRouter = Router()
+      specialRouter.get('/foo/:id', (request) => new Response(`id: ${request.params.id}`))
+
+      const response = await specialRouter.handle(buildRequest({ path: '/foo/user%3A1234' }))
+
+      expect(await response.text()).toBe('id: user:1234')
+    })
   })
 
   describe(`.handle({ method = 'GET', url }, ...args)`, () => {

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -94,7 +94,7 @@ export const Router = <
     }),
     routes,
     async handle (request: RequestLike, ...args)  {
-      let response, match, url = new URL(request.url), query: any = request.query = { __proto__: null }
+      let response, match, url = new URL(decodeURIComponent(request.url)), query: any = request.query = { __proto__: null }
       for (let [k, v] of url.searchParams) {
         query[k] = query[k] === undefined ? v : [query[k], v].flat()
       }


### PR DESCRIPTION
### Description
[Quote from itty-router-openapi/issues/88](https://github.com/cloudflare/itty-router-openapi/issues/88) @gimenete 

Given an endpoint like this:

```ts
router.get(
  "/something/:id",
  (request) => new Response(`id: ${request.params.id}`)
);
```

Making a query to `/something/user%3A1234` returns the following response: `id: user%3A1234`. While it should be `id: user:1234`.

The fix here was to `decodeURIComponent` the request url before parsing the parameters, i've also added a unit test for this, but now [this test](https://github.com/kwhitley/itty-router/blob/v4.x/src/Router.spec.ts#L528) is failing due to `URI malformed`.

@kwhitley can you propose a fix here, should i edit the failing test to a valid one?

### Type of Change (select one and follow subtasks)
- [x] Maintenance or repo-level work (e.g. linting, build, tests, refactoring, etc.)
- [x] Bug fix (non-breaking change which fixes an issue)
