### PR TITLE
Bugfix/ts expect error is a bug

### DIFF
--- a/src/Router.ts
+++ b/src/Router.ts
@@ -59,7 +59,6 @@ export const Router = <
   RequestType = IRequest,
   Args extends any[] = any[]
 >({ base = '', routes = [] }: RouterOptions = {}): RouterType<RequestType, Args> =>
-  // @ts-expect-error TypeScript doesn't know that Proxy makes this work
   ({
     __proto__: new Proxy({}, {
       // @ts-expect-error (we're adding an expected prop "path" to the get)
@@ -97,4 +96,4 @@ export const Router = <
         }
       }
     }
-  })
+  } as RouterType<RequestType, Args>)

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -25,18 +25,16 @@ export type RouterOptions = {
   routes?: RouteEntry[]
 }
 
-export type RouteHandler<R = IRequest, Args = any[]> = {
-  // @ts-expect-error - TS never likes this syntax
+export type RouteHandler<R = IRequest, Args extends Array<any> = any[]> = {
   (request: R, ...args: Args): any
 }
 
 export type RouteEntry = [string, RegExp, RouteHandler[], string]
 
 // this is the generic "Route", which allows per-route overrides
-export type Route<R = IRequest, A = any[]> = <RequestType = R, Args = A>(
+export type Route<R = IRequest, A extends Array<any> = any[]> = <RequestType = R, Args extends Array<any> = A>(
   path: string,
   ...handlers: RouteHandler<RequestType, Args>[]
-  // @ts-expect-error - fiddly2
 ) => RouterType<RequestType, Args>
 
 export type CustomRoutes<R = Route> = {

--- a/src/createCors.ts
+++ b/src/createCors.ts
@@ -7,8 +7,13 @@ export type CorsOptions = {
   headers?: any
 }
 
+export interface CorsFns {
+  corsify(req: Request): Response;
+  preflight(r: IRequest): Response;
+}
+
 // Create CORS function with default options.
-export const createCors = (options: CorsOptions = {}) => {
+export const createCors = (options: CorsOptions = {}): CorsFns => {
   // Destructure and set defaults for options.
   const {
     origins = ['*'],


### PR DESCRIPTION
### Description

This fixes a few type places where you opt out of TS with 'expect-error' in the flow branch. Most are just instances of missing `extends` that you actually already had elsewhere. One is using an `as` instead of an `ts-expect-error`.

The problem with the expect-error is that if you miss something else you could introduce bugs since it is _line_ level ignoring. By using an `as` you assert to the compiler it's getting something wrong, but in exchange the compiler trusts you and continues checking everything else that it can.

### Related Issue

Link to the related issue: None

### Type of Change (select one and follow subtasks)
- [ ] Documentation (README.md)
- [x] Maintenance or repo-level work (e.g. linting, build, tests, refactoring, etc.)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
  - [ ] I have included test coverage
- [ ] Breaking change (fix or feature that would cause existing functionality/userland code to not work as expected)
  - [ ] Explain why a breaking change is necessary:
- [ ] This change requires (or is) a documentation update
  - [ ] I have added necessary local documentation (if appropriate)
  - [ ] I have added necessary [itty.dev](https://github.com/kwhitley/itty.dev) documentation (if appropriate)
