### PR TITLE
DRAFT: baseless nested routers working (appx +50 bytes)

### DIFF
--- a/example/bun.ts
+++ b/example/bun.ts
@@ -1,4 +1,8 @@
-import { Router, error, json, text, withParams } from '../src'
+import { Router, error, json, text, withParams, RouterOptions, RouterType } from '../src'
+
+type CustomRouterType = RouterType & {
+  addLogging: (logger: Function) => CustomRouterType
+}
 
 const router = Router({ port: 3001 })
                 .all('*', withParams)

--- a/example/bun.ts
+++ b/example/bun.ts
@@ -1,15 +1,9 @@
-import { Router, error, json, withParams } from '../dist/index.js'
+import { Router, error, json, text, withParams } from '../src'
 
-const router = Router()
+const router = Router({ port: 3001 })
+                .all('*', withParams)
+                .get('/test', () => text('Success!'))
+                .get('/foo/:bar/:baz?', ({ bar, baz }) => json(({ bar, baz })))
+                .all('*', () => error(404))
 
-router
-  .all('*', withParams)
-  .get('/test', () => 'Success!')
-  .get('/foo/:bar/:baz?', ({ bar, baz }) => ({ bar, baz }))
-  .all('*', () => error(404))
-
-export default {
-  port: 3001,
-  fetch: (request, env, ctx) =>
-    router.handle(request, env, ctx).then(json).catch(error),
-}
+export default router

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itty-router",
-  "version": "4.0.25",
+  "version": "4.0.25-next.0",
   "description": "A tiny, zero-dependency router, designed to make beautiful APIs in any environment.",
   "main": "./index.js",
   "module": "./index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itty-router",
-  "version": "4.0.25-next.0",
+  "version": "4.0.25-next.1",
   "description": "A tiny, zero-dependency router, designed to make beautiful APIs in any environment.",
   "main": "./index.js",
   "module": "./index.mjs",

--- a/package.json
+++ b/package.json
@@ -143,8 +143,6 @@
     "@types/node": "^20.3.1",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "@typescript-eslint/parser": "^5.60.0",
-    "@vitejs/plugin-vue": "^4.2.3",
-    "@vitest/coverage-c8": "^0.32.2",
     "@vitest/coverage-v8": "^0.32.2",
     "@whatwg-node/server": "^0.8.12",
     "coveralls": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
       "require": "./html.js",
       "types": "./html.d.ts"
     },
+    "./IttyRouter": {
+      "import": "./IttyRouter.mjs",
+      "require": "./IttyRouter.js",
+      "types": "./IttyRouter.d.ts"
+    },
     "./jpeg": {
       "import": "./jpeg.mjs",
       "require": "./jpeg.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itty-router",
-  "version": "4.0.24",
+  "version": "4.0.24-next.0",
   "description": "A tiny, zero-dependency router, designed to make beautiful APIs in any environment.",
   "main": "./index.js",
   "module": "./index.mjs",

--- a/src/IttyRouter.ts
+++ b/src/IttyRouter.ts
@@ -1,0 +1,58 @@
+import {
+  Equal,
+  IRequest,
+  RequestLike,
+  Route,
+  RouterOptions,
+  RouterType,
+  UniversalRoute
+} from 'Router'
+
+export const IttyRouter = <
+  RequestType = IRequest,
+  Args extends any[] = any[],
+  RouteType = Equal<RequestType, IRequest> extends true ? Route : UniversalRoute<RequestType, Args>
+>({ base = '', routes = [], ...other }: RouterOptions = {}): RouterType<RouteType, Args> =>
+  // @ts-expect-error TypeScript doesn't know that Proxy makes this work
+  ({
+    __proto__: new Proxy({}, {
+      // @ts-expect-error (we're adding an expected prop "path" to the get)
+      get: (target: any, prop: string, receiver: RouterType, path: string) => (route: string, ...handlers: RouteHandlerOrRouter<I>[]) => {
+        routes.push(
+          [
+            prop.toUpperCase(),
+            RegExp(`^${(path = (base + route)
+              .replace(/\/+(\/|$)/g, '$1'))                       // strip double & trailing splash
+              .replace(/(\/?\.?):(\w+)\+/g, '($1(?<$2>*))')       // greedy params
+              .replace(/(\/?\.?):(\w+)/g, '($1(?<$2>[^$1/]+?))')  // named params and image format
+              .replace(/\./g, '\\.')                              // dot in path
+              .replace(/(\/?)\*/g, '($1.*)?')                     // wildcard
+            }/*$`),
+            handlers,                                             // embed handlers
+            path,                                                 // embed clean route path
+          ]
+        )
+
+        return receiver
+      }
+    }),
+    routes,
+    base,
+    ...other,
+    async fetch (request: RequestLike, ...args)  {
+      let response, match, url = new URL(request.url), query: Record<string, any> = request.query = { __proto__: null }
+
+      // 1. parse query params
+      for (let [k, v] of url.searchParams)
+        query[k] = query[k] ? ([] as string[]).concat(query[k], v) : v
+
+      // 2. then test routes
+      for (let [method, regex, handlers, path] of routes)
+        if ((method == request.method || method == 'ALL') && (match = url.pathname.match(regex))) {
+          request.params = match.groups || {}                                     // embed params in request
+          request.route = path                                                    // embed route path in request
+          for (let handler of handlers)
+            if ((response = await handler(request.proxy ?? request, ...args)) != null) return response
+        }
+    },
+  })

--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -509,23 +509,31 @@ describe('NESTING', () => {
   })
 
   it('can pass routers as handlers (without explicit base path)', async () => {
-    const child = Router().get('/', () => 'child')
+    const grandchild = Router().get('/', () => 'grandchild')
+    const child = Router()
+                    .get('/', () => 'child')
+                    .get('/grandchild/*', grandchild)
     const parent = Router()
                     .get('/', () => 'parent')
                     .all('/child/*', child)
 
     expect(await parent.handle(buildRequest({ path: '/' }))).toBe('parent')
     expect(await parent.handle(buildRequest({ path: '/child' }))).toBe('child')
+    expect(await parent.handle(buildRequest({ path: '/child/grandchild' }))).toBe('grandchild')
   })
 
   it('can pass routers as handlers (WITH explicit base path)', async () => {
-    const child = Router({ base: '/child' }).get('/', () => 'child')
+    const grandchild = Router({ base: '/child/grandchild' }).get('/', () => 'grandchild')
+    const child = Router({ base: '/child' })
+                    .get('/', () => 'child')
+                    .get('/grandchild/*', grandchild)
     const parent = Router()
                     .get('/', () => 'parent')
                     .all('/child/*', child)
 
     expect(await parent.handle(buildRequest({ path: '/' }))).toBe('parent')
     expect(await parent.handle(buildRequest({ path: '/child' }))).toBe('child')
+    expect(await parent.handle(buildRequest({ path: '/child/grandchild' }))).toBe('grandchild')
   })
 })
 

--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -116,6 +116,13 @@ describe('Router', () => {
       expect(typeof response?.catch).toBe('function')
     })
 
+    it('is aliased through router.fetch', async () => {
+      const router = Router().get('/foo', () => 'bar')
+      const response = await router.fetch(toReq('/foo'))
+
+      expect(response).toBe('bar')
+    })
+
     it('returns { path, query } from match', async () => {
       const route = routes.find((r) => r.path === '/foo/:id')
       await router.handle(toReq('/foo/13?foo=bar&cat=dog'))

--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -547,17 +547,6 @@ describe('NESTING', () => {
     expect(await parent.handle(toReq('/child/kitten'))).toBe('child')
   })
 
-  it('can nest with route params on the nested route if NOT given router.handle and base path', async () => {
-    const child = Router().get('/', () => 'child')
-    const parent = Router()
-                    .get('/', () => 'parent')
-                    .all('/child/:bar/*', child.handle)
-
-    expect(await parent.handle(toReq('/'))).toBe('parent')
-    expect(await parent.handle(toReq('/child/kitten'))).toBe('child')
-  })
-
-
   it('can pass routers as handlers (WITH explicit base path)', async () => {
     const grandchild = Router({ base: '/child/grandchild' }).get('/', () => 'grandchild')
     const child = Router({ base: '/child' })

--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -517,6 +517,8 @@ describe('NESTING', () => {
                     .get('/', () => 'parent')
                     .all('/child/*', child)
 
+                    console.log({ child, parent })
+
     expect(await parent.handle(buildRequest({ path: '/' }))).toBe('parent')
     expect(await parent.handle(buildRequest({ path: '/child' }))).toBe('child')
     expect(await parent.handle(buildRequest({ path: '/child/grandchild' }))).toBe('grandchild')

--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -74,11 +74,16 @@ describe('Router', () => {
   })
 
   it('allows easy custom Router creation', async () => {
-    const logger = vi.fn()
+    const logger = vi.fn() // vitest spy function
 
+    // create a CustomRouter that creates a Router with some predefined options
     const CustomRouter = (options = {}) => Router({
-      ...options,
+      ...options, // we still want to pass in any real options
+
+      // but let's add one to
       getMethods: function() { return Array.from(this.routes.reduce((acc, [method]) => acc.add(method), new Set())) },
+
+      // and a chaining function to "rewire" and intercept fetch requests
       addLogging: function(logger = () => {}) {
         const ogFetch = this.fetch
         this.fetch = (...args) => {
@@ -86,14 +91,15 @@ describe('Router', () => {
           return ogFetch(...args)
         }
 
-        return this
+        return this // this let's us chain
       }
     })
 
+    // implement the CustomRouter
     const router = CustomRouter()
                     .get('/', () => 'foo')
                     .post('/', () => {})
-                    .addLogging(logger)
+                    .addLogging(logger) // we added this!
 
     const response = await router.fetch(toReq('/'))
 

--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -547,6 +547,17 @@ describe('NESTING', () => {
     expect(await parent.handle(toReq('/child/kitten'))).toBe('child')
   })
 
+  it('can nest with route params on the nested route if NOT given router.handle and base path', async () => {
+    const child = Router().get('/', () => 'child')
+    const parent = Router()
+                    .get('/', () => 'parent')
+                    .all('/child/:bar/*', child.handle)
+
+    expect(await parent.handle(toReq('/'))).toBe('parent')
+    expect(await parent.handle(toReq('/child/kitten'))).toBe('child')
+  })
+
+
   it('can pass routers as handlers (WITH explicit base path)', async () => {
     const grandchild = Router({ base: '/child/grandchild' }).get('/', () => 'grandchild')
     const child = Router({ base: '/child' })

--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -522,18 +522,29 @@ describe('NESTING', () => {
     expect(await parent.handle(buildRequest({ path: '/child/grandchild' }))).toBe('grandchild')
   })
 
-  // CURRENTLY FAILS
-  // it('can nest with route params on the nested route', async () => {
-  //   const child = Router({ base: '/child/:bar' }).get('*', ({ url }) => url.href)
-  //   const parent = Router()
-  //                   .get('/', () => 'parent')
-  //                   .all('/child/:bar/*', child)
+  it('can nest with route params on the nested route (only if given child base path)', async () => {
+    const child = Router({ base: '/child/:bar' }).get('/', () => 'child')
+    const parent = Router()
+                    .get('/', () => 'parent')
+                    .all('/child/:bar/*', child)
 
-  //   console.log({ child: child.routes, parent: parent.routes })
+    console.log({ child: child.routes, parent: parent.routes })
 
-  //   expect(await parent.handle(buildRequest({ path: '/' }))).toBe('parent')
-  //   expect(await parent.handle(buildRequest({ path: '/child/kitten' }))).toBe('child')
-  // })
+    expect(await parent.handle(buildRequest({ path: '/' }))).toBe('parent')
+    expect(await parent.handle(buildRequest({ path: '/child/kitten' }))).toBe('child')
+  })
+
+  it('can nest with route params on the nested route if given router.handle and base path', async () => {
+    const child = Router({ base: '/child/:bar' }).get('/', () => 'child')
+    const parent = Router()
+                    .get('/', () => 'parent')
+                    .all('/child/:bar/*', child.handle)
+
+    console.log({ child: child.routes, parent: parent.routes })
+
+    expect(await parent.handle(buildRequest({ path: '/' }))).toBe('parent')
+    expect(await parent.handle(buildRequest({ path: '/child/kitten' }))).toBe('child')
+  })
 
   it('can pass routers as handlers (WITH explicit base path)', async () => {
     const grandchild = Router({ base: '/child/grandchild' }).get('/', () => 'grandchild')

--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -526,8 +526,6 @@ describe('NESTING', () => {
                     .get('/', () => 'parent')
                     .all('/child/:bar/*', child)
 
-    console.log({ child: child.routes, parent: parent.routes })
-
     expect(await parent.handle(toReq('/'))).toBe('parent')
     expect(await parent.handle(toReq('/child/kitten'))).toBe('child')
   })
@@ -537,8 +535,6 @@ describe('NESTING', () => {
     const parent = Router()
                     .get('/', () => 'parent')
                     .all('/child/:bar/*', child.handle)
-
-    console.log({ child: child.routes, parent: parent.routes })
 
     expect(await parent.handle(toReq('/'))).toBe('parent')
     expect(await parent.handle(toReq('/child/kitten'))).toBe('child')

--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -508,7 +508,7 @@ describe('NESTING', () => {
     expect(handler3).toHaveBeenCalled()
   })
 
-  it('can pass routers as handlers (without explicit base path)', async () => {
+  it('can pass routers as handlers (WITHOUT explicit base path)', async () => {
     const grandchild = Router().get('/', () => 'grandchild')
     const child = Router()
                     .get('/', () => 'child')
@@ -517,12 +517,23 @@ describe('NESTING', () => {
                     .get('/', () => 'parent')
                     .all('/child/*', child)
 
-                    console.log({ child, parent })
-
     expect(await parent.handle(buildRequest({ path: '/' }))).toBe('parent')
     expect(await parent.handle(buildRequest({ path: '/child' }))).toBe('child')
     expect(await parent.handle(buildRequest({ path: '/child/grandchild' }))).toBe('grandchild')
   })
+
+  // CURRENTLY FAILS
+  // it('can nest with route params on the nested route', async () => {
+  //   const child = Router({ base: '/child/:bar' }).get('*', ({ url }) => url.href)
+  //   const parent = Router()
+  //                   .get('/', () => 'parent')
+  //                   .all('/child/:bar/*', child)
+
+  //   console.log({ child: child.routes, parent: parent.routes })
+
+  //   expect(await parent.handle(buildRequest({ path: '/' }))).toBe('parent')
+  //   expect(await parent.handle(buildRequest({ path: '/child/kitten' }))).toBe('child')
+  // })
 
   it('can pass routers as handlers (WITH explicit base path)', async () => {
     const grandchild = Router({ base: '/child/grandchild' }).get('/', () => 'grandchild')

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -118,6 +118,7 @@ export const Router = <
       }
     }),
     routes,
+    base,
     async handle (request: RequestLike, ...args)  {
       let response, match, url = new URL(request.url), query: Record<string, any> = request.query = { __proto__: null }
 

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -96,7 +96,7 @@ export const Router = <
 
         routes.push(
           [
-            prop?.toUpperCase?.(),
+            prop.toUpperCase?.(),
             RegExp(`^${(path = (base + route)
               .replace(/\/+(\/|$)/g, '$1'))                       // strip double & trailing splash
               .replace(/(\/?\.?):(\w+)\+/g, '($1(?<$2>*))')       // greedy params

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -106,7 +106,7 @@ export const Router = <
               .replace(/\./g, '\\.')                              // dot in path
               .replace(/(\/?)\*/g, '($1.*)?')                     // wildcard
             }/*$`),
-            // @ts-expect-error
+            // @ts-expect-error - not worth fixing for an internal type
             handlers,                                             // embed handlers
             path,                                                 // embed clean route path
           ]

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -100,7 +100,7 @@ export const Router = <
 
         routes.push(
           [
-            prop.toUpperCase?.(),
+            prop.toUpperCase(),
             RegExp(`^${(path = (base + route)
               .replace(/\/+(\/|$)/g, '$1'))                       // strip double & trailing splash
               .replace(/(\/?\.?):(\w+)\+/g, '($1(?<$2>*))')       // greedy params

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -29,7 +29,7 @@ export type RouterOptions = {
 
 export type RouteHandler<I = IRequest, A extends any[] = any[]> = {
   (request: I, ...args: A): any
-}
+} & MayBeRouter
 
 export type RouteEntry = [string, RegExp, RouteHandler[], string]
 
@@ -51,6 +51,11 @@ type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y 
 
 export type CustomRoutes<R = Route> = {
   [key: string]: R,
+}
+
+type MayBeRouter = {
+  handle?: any
+  base?: string
 }
 
 export type RouterType<R = Route, Args extends any[] = any[]> = {
@@ -81,14 +86,11 @@ export const Router = <
       // @ts-expect-error (we're adding an expected prop "path" to the get)
       get: (target: any, prop: string, receiver: RouterType, path: string) => (route: string, ...handlers: RouteHandlerOrRouter<I>[]) => {
         handlers = handlers.map(h =>
-          // @ts-expect-error
           h.handle
-          // @ts-expect-error
             ? h.base ? h.handle : (r, ...args) => {
                 r.url = new URL(r.url)
                 r.url.pathname = r.url.pathname.replace(route.replace(/\/\*$/, ''), '')
 
-                // @ts-expect-error
                 return h.handle(r, ...args)
               }
             : h

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -85,6 +85,8 @@ export const Router = <
     __proto__: new Proxy({}, {
       // @ts-expect-error (we're adding an expected prop "path" to the get)
       get: (target: any, prop: string, receiver: RouterType, path: string) => (route: string, ...handlers: RouteHandlerOrRouter<I>[]) => {
+
+        // this remaps handlers to allow for nested routers as handlers
         handlers = handlers.map(h =>
           h.handle
             ? h.base ? h.handle : (r, ...args) => {

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -62,6 +62,7 @@ export type RouterType<R = Route, Args extends any[] = any[]> = {
   __proto__: RouterType<R>,
   routes: RouteEntry[],
   handle: <A extends any[] = Args>(request: RequestLike, ...extra: Equal<R, Args> extends true ? A : Args) => Promise<any>
+  fetch: <A extends any[] = Args>(request: RequestLike, ...extra: Equal<R, Args> extends true ? A : Args) => Promise<any>
   base: string,
   all: R,
   delete: R,
@@ -85,6 +86,9 @@ export const Router = <
     __proto__: new Proxy({}, {
       // @ts-expect-error (we're adding an expected prop "path" to the get)
       get: (target: any, prop: string, receiver: RouterType, path: string) => (route: string, ...handlers: RouteHandlerOrRouter<I>[]) => {
+        // @ts-expect-error - patch for aliasing router.fetch
+        if (prop == 'fetch') return receiver.handle(route, ...handlers)
+
         // this remaps handlers to allow for nested routers as handlers
         handlers = handlers.map(h =>
           h.handle

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -87,7 +87,7 @@ export const Router = <
       // @ts-expect-error (we're adding an expected prop "path" to the get)
       get: (target: any, prop: string, receiver: RouterType, path: string) => (route: string, ...handlers: RouteHandlerOrRouter<I>[]) => {
         // @ts-expect-error - patch for aliasing router.fetch
-        if (prop == 'fetch') return receiver.handle(route, ...handlers)
+        if (prop == 'handle') return receiver.fetch(route, ...handlers)
 
         // this remaps handlers to allow for nested routers as handlers
         handlers = handlers.map(h =>
@@ -122,7 +122,7 @@ export const Router = <
     }),
     routes,
     base,
-    async handle (request: RequestLike, ...args)  {
+    async fetch (request: RequestLike, ...args)  {
       let response, match, url = new URL(request.url), query: Record<string, any> = request.query = { __proto__: null }
 
       // 1. parse query params

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -25,7 +25,7 @@ export type IRequest = IRequestStrict & GenericTraps
 export type RouterOptions = {
   base?: string
   routes?: RouteEntry[]
-}
+} & Record<string, any>
 
 export type RouteHandler<I = IRequest, A extends any[] = any[]> = {
   (request: I, ...args: A): any
@@ -52,7 +52,7 @@ export type UniversalRoute<RequestType = IRequest, Args extends any[] = any[]> =
 ) => RouterType<UniversalRoute<RequestType, Args>, Args>
 
 // helper function to detect equality in types (used to detect custom Request on router)
-type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? true : false;
+export type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? true : false;
 
 export type CustomRoutes<R = Route> = {
   [key: string]: R,
@@ -78,7 +78,7 @@ export type RouterType<R = Route, Args extends any[] = any[]> = {
   patch: R,
   post: R,
   put: R,
-} & CustomRoutes<R>
+} & CustomRoutes<R> & Record<string, any>
 
 type RouteHandlerOrRouter<RequestType = IRequest, Args extends any[] = any[]> = RouteHandler<RequestType, Args> | RouterType
 
@@ -86,7 +86,7 @@ export const Router = <
   RequestType = IRequest,
   Args extends any[] = any[],
   RouteType = Equal<RequestType, IRequest> extends true ? Route : UniversalRoute<RequestType, Args>
->({ base = '', routes = [] }: RouterOptions = {}): RouterType<RouteType, Args> =>
+>({ base = '', routes = [], ...other }: RouterOptions = {}): RouterType<RouteType, Args> =>
   // @ts-expect-error TypeScript doesn't know that Proxy makes this work
   ({
     __proto__: new Proxy({}, {
@@ -128,6 +128,7 @@ export const Router = <
     }),
     routes,
     base,
+    ...other,
     async fetch (request: RequestLike, ...args)  {
       let response, match, url = new URL(request.url), query: Record<string, any> = request.query = { __proto__: null }
 

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -85,7 +85,6 @@ export const Router = <
     __proto__: new Proxy({}, {
       // @ts-expect-error (we're adding an expected prop "path" to the get)
       get: (target: any, prop: string, receiver: RouterType, path: string) => (route: string, ...handlers: RouteHandlerOrRouter<I>[]) => {
-
         // this remaps handlers to allow for nested routers as handlers
         handlers = handlers.map(h =>
           h.handle

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -29,7 +29,7 @@ export type RouterOptions = {
 
 export type RouteHandler<I = IRequest, A extends any[] = any[]> = {
   (request: I, ...args: A): any
-} & MayBeRouter
+} & MaybeRouter
 
 export type RouteEntry = [string, RegExp, RouteHandler[], string]
 
@@ -53,8 +53,9 @@ export type CustomRoutes<R = Route> = {
   [key: string]: R,
 }
 
-type MayBeRouter = {
+type MaybeRouter = {
   handle?: any
+  fetch?: any
   base?: string
 }
 
@@ -91,12 +92,12 @@ export const Router = <
 
         // this remaps handlers to allow for nested routers as handlers
         handlers = handlers.map(h =>
-          h.handle
-            ? h.base ? h.handle : (r, ...args) => {
+          h.fetch
+            ? h.base ? h.fetch : (r, ...args) => {
                 r.url = new URL(r.url)
                 r.url.pathname = r.url.pathname.replace(route.replace(/\/\*$/, ''), '')
 
-                return h.handle(r, ...args)
+                return h.fetch(r, ...args)
               }
             : h
         )

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './Router'
+export * from './IttyRouter'
 
 // classes
 export * from './StatusError'

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,12 +1,21 @@
 /* istanbul ignore file */
 import { expect, it, vi } from 'vitest'
 
-export const buildRequest = ({
-  method = 'GET',
-  path,
-  url = `https://example.com${path}`,
-  ...other
-}) => ({ method, path, url, ...other })
+// generates a request from a string like:
+// GET /whatever
+// /foo
+export const toReq = (methodAndPath: string) => {
+  let [method, path] = methodAndPath.split(' ')
+  if (!path) {
+    path = method
+    method = 'GET'
+  }
+
+  return {
+    method,
+    url: `https://example.com${path}`
+  }
+}
 
 export const extract = ({ params, query }) => ({ params, query })
 
@@ -27,7 +36,7 @@ const testRoute = async (
     path,
   })
 
-  await router.handle(buildRequest({ method: method.toUpperCase(), path }))
+  await router.handle(toReq(`${method.toUpperCase()} ${path}`))
 
   if (!returns) {
     expect(handler).not.toHaveBeenCalled()

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,7 +466,7 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
-"@istanbuljs/schema@^0.1.2", "@istanbuljs/schema@^0.1.3":
+"@istanbuljs/schema@^0.1.2":
   version "0.1.3"
   resolved "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
@@ -820,26 +820,10 @@
     "@typescript-eslint/types" "5.60.0"
     eslint-visitor-keys "^3.3.0"
 
-"@vitejs/plugin-vue@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-4.2.3.tgz#ee0b6dfcc62fe65364e6395bf38fa2ba10bb44b6"
-  integrity sha512-R6JDUfiZbJA9cMiguQ7jxALsgiprjBeHL5ikpXfJCH62pPHtI+JdJ5xWj6Ev73yXSlYl86+blXn1kZHQ7uElxw==
-
-"@vitest/coverage-c8@^0.32.2":
-  version "0.32.2"
-  resolved "https://registry.yarnpkg.com/@vitest/coverage-c8/-/coverage-c8-0.32.2.tgz#dc0e1159d07bd6eb343529046d0f50521b673c3f"
-  integrity sha512-z07kMTN6e4t1jDY4XXU6W1LxCb3V5Rw7KAZId4VM6BCIGLGz1QqwH9UWYWv7LemqQVnARl5CwaDDwVrkcYgwPg==
-  dependencies:
-    "@ampproject/remapping" "^2.2.1"
-    c8 "^7.13.0"
-    magic-string "^0.30.0"
-    picocolors "^1.0.0"
-    std-env "^3.3.2"
-
 "@vitest/coverage-v8@^0.32.2":
-  version "0.32.2"
-  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-0.32.2.tgz#efb74efd47ccdea59874c700f93f8c30b5766ab9"
-  integrity sha512-/+V3nB3fyeuuSeKxCfi6XmWjDIxpky7AWSkGVfaMjAk7di8igBwRsThLjultwIZdTDH1RAxpjmCXEfSqsMFZOA==
+  version "0.32.4"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-0.32.4.tgz#b11c182f52898f34f7cc5cf3aaa05e71528f7b7e"
+  integrity sha512-itiCYY3TmWEK+5wnFBoNr0ZA+adACp7Op1r2TeX5dPOgU2See7+Gx2NlK2lVMHVxfPsu5z9jszKa3i//eR+hqg==
   dependencies:
     "@ampproject/remapping" "^2.2.1"
     "@bcoe/v8-coverage" "^0.2.3"
@@ -849,7 +833,7 @@
     istanbul-reports "^3.1.5"
     magic-string "^0.30.0"
     picocolors "^1.0.0"
-    std-env "^3.3.2"
+    std-env "^3.3.3"
     test-exclude "^6.0.0"
     v8-to-istanbul "^9.1.0"
 
@@ -1155,24 +1139,6 @@ busboy@^1.6.0:
   dependencies:
     streamsearch "^1.1.0"
 
-c8@^7.13.0:
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/c8/-/c8-7.13.0.tgz#a2a70a851278709df5a9247d62d7f3d4bcb5f2e4"
-  integrity sha512-/NL4hQTv1gBL6J6ei80zu3IiTrmePDKXKXOTLpHvcIWZTVYQlDhVWjjWvkhICylE8EwwnMVzDZugCvdx0/DIIA==
-  dependencies:
-    "@bcoe/v8-coverage" "^0.2.3"
-    "@istanbuljs/schema" "^0.1.3"
-    find-up "^5.0.0"
-    foreground-child "^2.0.0"
-    istanbul-lib-coverage "^3.2.0"
-    istanbul-lib-report "^3.0.0"
-    istanbul-reports "^3.1.4"
-    rimraf "^3.0.2"
-    test-exclude "^6.0.0"
-    v8-to-istanbul "^9.0.0"
-    yargs "^16.2.0"
-    yargs-parser "^20.2.9"
-
 cac@^6.7.14:
   version "6.7.14"
   resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
@@ -1272,15 +1238,6 @@ cli-width@^3.0.0:
   resolved "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
-cliui@^7.0.2:
-  version "7.0.4"
-  resolved "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz"
-  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
-  dependencies:
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
-    wrap-ansi "^7.0.0"
-
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"
@@ -1346,10 +1303,15 @@ concordance@^5.0.4:
     semver "^7.3.2"
     well-known-symbols "^2.0.0"
 
-convert-source-map@^1.6.0, convert-source-map@^1.7.0:
+convert-source-map@^1.7.0:
   version "1.9.0"
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
+
+convert-source-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
+  integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
 core-js@^3.0.0:
   version "3.25.5"
@@ -1909,14 +1871,6 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-foreground-child@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz"
-  integrity sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==
-  dependencies:
-    cross-spawn "^7.0.0"
-    signal-exit "^3.0.2"
-
 foreground-child@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.1.1.tgz#1d173e776d75d2772fed08efe4a0de1ea1b12d0d"
@@ -2010,11 +1964,6 @@ gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
-
-get-caller-file@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
-  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-func-name@^2.0.0:
   version "2.0.2"
@@ -2551,10 +2500,10 @@ istanbul-lib-source-maps@^4.0.1:
     istanbul-lib-coverage "^3.0.0"
     source-map "^0.6.1"
 
-istanbul-reports@^3.1.4, istanbul-reports@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz"
-  integrity sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==
+istanbul-reports@^3.1.5:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.6.tgz#2544bcab4768154281a2f0870471902704ccaa1a"
+  integrity sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
@@ -3328,11 +3277,6 @@ request@^2.88.2:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-require-directory@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
-  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
-
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
@@ -3640,6 +3584,11 @@ std-env@^3.3.2:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.3.3.tgz#a54f06eb245fdcfef53d56f3c0251f1d5c3d01fe"
   integrity sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==
 
+std-env@^3.3.3:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.6.0.tgz#94807562bddc68fa90f2e02c5fd5b6865bb4e98e"
+  integrity sha512-aFZ19IgVmhdB2uX599ve2kE6BIE3YMnQ6Gp6BURhW/oIzpXGKr878TQfAQZn1+i0Flcc/UKUy1gOlcfaUBCryg==
+
 streamsearch@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
@@ -3662,15 +3611,6 @@ string-width@^4.1.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string-width@^4.2.0:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -4047,23 +3987,14 @@ v8-compile-cache-lib@^3.0.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
-v8-to-istanbul@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz"
-  integrity sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==
-  dependencies:
-    "@jridgewell/trace-mapping" "^0.3.12"
-    "@types/istanbul-lib-coverage" "^2.0.1"
-    convert-source-map "^1.6.0"
-
 v8-to-istanbul@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz#1b83ed4e397f58c85c266a570fc2558b5feb9265"
-  integrity sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz#2ed7644a245cddd83d4e087b9b33b3e62dfd10ad"
+  integrity sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
-    convert-source-map "^1.6.0"
+    convert-source-map "^2.0.0"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
@@ -4252,15 +4183,6 @@ word-wrap@^1.2.3:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
 wrap-ansi@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
@@ -4290,33 +4212,15 @@ xmlchars@^2.2.0:
   resolved "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-y18n@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
-  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
 yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.9:
+yargs-parser@^20.2.3:
   version "20.2.9"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
-
-yargs@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz"
-  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
-  dependencies:
-    cliui "^7.0.2"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.0"
-    y18n "^5.0.5"
-    yargs-parser "^20.2.2"
 
 yarn-release@^1.10.6:
   version "1.10.6"


### PR DESCRIPTION
### Description
This adds a new way to nest routers, by passing the entire router as a handler.  With this method, child routers do not need explicit base paths set.

```ts
const child = Router().get('/', () => 'child')

const parent = Router()
                 .get('/', () => 'parent')
                 .all('/child/*', child)
```

### Notes
- This will only work with simple prefixes, not ones like `/child/:foo/*`.  For that to work, specify the base path in the child router as before.
- Specifying the base path of child routers will still be faster, as no per-request manipulation needs to be done

### Type of Change (select one and follow subtasks)
- [ ] Documentation (README.md)
- [ ] Maintenance or repo-level work (e.g. linting, build, tests, refactoring, etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
  - [x] I have included test coverage
- [ ] Breaking change (fix or feature that would cause existing functionality/userland code to not work as expected)
  - [ ] Explain why a breaking change is necessary:
- [ ] This change requires (or is) a documentation update
  - [ ] I have added necessary local documentation (if appropriate)
  - [ ] I have added necessary [itty.dev](https://github.com/kwhitley/itty.dev) documentation (if appropriate)
