### PR TITLE
DRAFT: adds flow options to basic Router, as well as custom option/object passthrough

### DIFF
--- a/example/bun-custom-router.ts
+++ b/example/bun-custom-router.ts
@@ -1,0 +1,20 @@
+import { Router, RouterType, error, json, withParams } from '../src/index'
+
+const CustomRouter = (options = {}): RouterType =>
+  Router({
+    port: 3000,
+    after: json,
+    errors: error,
+    ...options
+  })
+
+const router = CustomRouter()
+
+router
+  .all('*', withParams)
+  .get('/test', () => 'Success!')
+  .get('/foo/:bar/:baz?', ({ bar, baz }) => ({ bar, baz }))
+  .get('/throw', (a) => a.b.c) // this is caught!
+  .all('*', () => error(404))
+
+export default router

--- a/example/bun.ts
+++ b/example/bun.ts
@@ -1,15 +1,16 @@
-import { Router, error, json, withParams } from '../dist/index.js'
+import { Router, error, json, withParams } from '../src/index'
 
-const router = Router()
+const router = Router({
+  port: 3001,
+  after: json,
+  errors: error,
+})
 
 router
   .all('*', withParams)
   .get('/test', () => 'Success!')
   .get('/foo/:bar/:baz?', ({ bar, baz }) => ({ bar, baz }))
+  .get('/throw', (a) => a.b.c) // this is caught!
   .all('*', () => error(404))
 
-export default {
-  port: 3001,
-  fetch: (request, env, ctx) =>
-    router.handle(request, env, ctx).then(json).catch(error),
-}
+export default router

--- a/example/bun.ts
+++ b/example/bun.ts
@@ -1,15 +1,19 @@
-import { Router, error, json, withParams } from '../src/index'
+import { Router, createCors, error, json, text, withParams } from '../src/index'
+
+const { preflight, corsify } = createCors()
 
 const router = Router({
   port: 3001,
-  after: json,
-  errors: error,
+  // after: json,
+  after: r => corsify(json(r)),
+  error,
 })
 
 router
-  .all('*', withParams)
-  .get('/test', () => 'Success!')
-  .get('/foo/:bar/:baz?', ({ bar, baz }) => ({ bar, baz }))
+  .all('*', withParams, preflight)
+  .get('/test', () => text('Success!'))
+  .post('/test', () => text('Post Success!'))
+  .get('/foo/:bar/:baz?', ({ bar, baz }) => json({ bar, baz }))
   .get('/throw', (a) => a.b.c) // this is caught!
   .all('*', () => error(404))
 

--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -486,11 +486,22 @@ describe('OPTIONS', () => {
 
   describe('errors: ErrorHandler', () => {
     it('catches errors', async () => {
-      const errors = vi.fn()
-      const router = Router({ errors }).get('/throw', (a) => a.b.c)
+      const error = vi.fn()
+      const router = Router({ error }).get('/throw', (a) => a.b.c)
       await router.fetch(toReq('/throw'))
 
-      expect(errors).toHaveBeenCalled()
+      expect(error).toHaveBeenCalled()
+    })
+  })
+
+  describe('errors: ErrorHandler', () => {
+    it('catches errors in the after phase', async () => {
+      const error = vi.fn()
+      const after = a => a.b.c
+      const router = Router({ after, error }).get('/', () => 'foo')
+      await router.fetch(toReq('/'))
+
+      expect(error).toHaveBeenCalled()
     })
   })
 })

--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -183,14 +183,14 @@ describe('Router', () => {
       const route = routes.find((r) => r.path === '/foo' && r.method === 'post')
       await router.handle(toReq('POST /foo'))
 
-      expect(route!.callback).toHaveBeenCalled()
+      expect(route?.callback).toHaveBeenCalled()
     })
 
     it('passes the entire original request through to the handler', async () => {
       const route = routes.find((r) => r.path === '/passthrough')
       await router.handle({ ...toReq('/passthrough'), name: 'miffles' })
 
-      expect(route!.callback).toHaveReturnedWith({
+      expect(route?.callback).toHaveReturnedWith({
         method: 'GET',
         name: 'miffles',
       })

--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -459,6 +459,26 @@ describe('Router', () => {
   })
 })
 
+describe('OPTIONS', () => {
+  describe('base: string', () => {
+    it('allows a base path to pre prepended to all routes', async () => {
+      const router = Router({ base: '/api' }).get('/foo', () => 'Foo')
+
+      expect(await router.fetch(toReq('/api/foo'))).toBe('Foo')
+    })
+  })
+
+  describe('format: Function', () => {
+    it('allows a formatting function to modify unformed responses', async () => {
+      const spy = vi.fn(v => v)
+      const router = Router({ after: spy }).get('/foo', () => 'Foo')
+      await router.fetch(toReq('/foo'))
+
+      expect(spy).toHaveBeenCalledWith('Foo')
+    })
+  })
+})
+
 describe('CUSTOM ROUTERS/PROPS', () => {
   it('allows overloading custom properties via options', () => {
     const router = Router({ port: 3001 })

--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -468,13 +468,23 @@ describe('OPTIONS', () => {
     })
   })
 
-  describe('format: Function', () => {
+  describe('after: ResponseHandler', () => {
     it('allows a formatting function to modify unformed responses', async () => {
       const spy = vi.fn(v => v)
       const router = Router({ after: spy }).get('/foo', () => 'Foo')
       await router.fetch(toReq('/foo'))
 
       expect(spy).toHaveBeenCalledWith('Foo')
+    })
+  })
+
+  describe('errors: ErrorHandler', () => {
+    it('catches errors', async () => {
+      const errors = vi.fn()
+      const router = Router({ errors }).get('/throw', (a) => a.b.c)
+      await router.fetch(toReq('/throw'))
+
+      expect(errors).toHaveBeenCalled()
     })
   })
 })

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -30,7 +30,7 @@ export type RouterOptions = {
   base?: string
   routes?: RouteEntry[]
   after?: ResponseHandler
-  errors?: ErrorHandler
+  error?: ErrorHandler
 } & Record<string, any>
 
 export type RouteHandler<I = IRequest, A extends any[] = any[]> = {
@@ -70,7 +70,7 @@ export type RouterType<R = Route, Args extends any[] = any[]> = {
   fetch: <A extends any[] = Args>(request: RequestLike, ...extra: Equal<R, Args> extends true ? A : Args) => Promise<any>
   handle: <A extends any[] = Args>(request: RequestLike, ...extra: Equal<R, Args> extends true ? A : Args) => Promise<any>
   after: ResponseHandler
-  errors: ErrorHandler
+  error: ErrorHandler
   all: R,
   delete: R,
   get: R,
@@ -127,9 +127,9 @@ export const Router = <
             try {
               if ((response = await handler(request.proxy ?? request, ...args)) != null)
                 return options.after ? options.after(response) : response
-            } catch(err) {
-              if (options.errors)
-                return options.errors(err)
+            } catch(err: any) {
+              if (options.error)
+                return await (options.error(err)).then
               throw err
             }
         }

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -22,11 +22,15 @@ export type IRequestStrict = {
 
 export type IRequest = IRequestStrict & GenericTraps
 
+export type ErrorHandler = <ErrorType extends Error>(error: ErrorType) => any
+
+export type ResponseHandler = <ResponseType = any>(response: ResponseType) => any
+
 export type RouterOptions = {
   base?: string
   routes?: RouteEntry[]
-  after?: Function
-  errors?: Function
+  after?: ResponseHandler
+  errors?: ErrorHandler
 } & Record<string, any>
 
 export type RouteHandler<I = IRequest, A extends any[] = any[]> = {
@@ -65,8 +69,8 @@ export type RouterType<R = Route, Args extends any[] = any[]> = {
   routes: RouteEntry[],
   fetch: <A extends any[] = Args>(request: RequestLike, ...extra: Equal<R, Args> extends true ? A : Args) => Promise<any>
   handle: <A extends any[] = Args>(request: RequestLike, ...extra: Equal<R, Args> extends true ? A : Args) => Promise<any>
-  after: Function
-  errors: Function
+  after: ResponseHandler
+  errors: ErrorHandler
   all: R,
   delete: R,
   get: R,

--- a/src/createCors.ts
+++ b/src/createCors.ts
@@ -7,13 +7,15 @@ export type CorsOptions = {
   headers?: any
 }
 
+type CorsifyType = <InputResponseType = Response>(response: InputResponseType) => Response
+
 // Create CORS function with default options.
 export const createCors = (options: CorsOptions = {}) => {
   // Destructure and set defaults for options.
   const { origins = ['*'], maxAge, methods = ['GET'], headers = {} } = options
 
   let allowOrigin: any
-  const isAllowOrigin = typeof origins === 'function' 
+  const isAllowOrigin = typeof origins === 'function'
     ? origins
     : (origin: string) => (origins.includes(origin) || origins.includes('*'))
 
@@ -47,6 +49,8 @@ export const createCors = (options: CorsOptions = {}) => {
         ...allowOrigin,
       }
 
+      console.log('CORS headers', reqHeaders)
+
       // Handle CORS pre-flight request.
       return new Response(null, {
         headers:
@@ -60,7 +64,7 @@ export const createCors = (options: CorsOptions = {}) => {
   }
 
   // Corsify function.
-  const corsify = (response: Response): Response => {
+  const corsify: CorsifyType = (response) => {
     if (!response)
       throw new Error(
         'No fetch handler responded and no upstream to proxy to specified.'

--- a/src/createCors.ts
+++ b/src/createCors.ts
@@ -63,13 +63,14 @@ export const createCors = (options: CorsOptions = {}) => {
     }
   }
 
-  // Corsify function.
+  // @ts-expect-error - intentional
   const corsify: CorsifyType = (response) => {
     if (!response)
       throw new Error(
         'No fetch handler responded and no upstream to proxy to specified.'
       )
 
+    // @ts-expect-error - alos intentional flexibility
     const { headers, status, body } = response
 
     // Bypass for protocol shifts or redirects, or if CORS is already set.

--- a/src/error.ts
+++ b/src/error.ts
@@ -21,20 +21,17 @@ const getMessage = (code: number): string => ({
 })[code] || 'Unknown Error'
 
 export const error: ErrorFormatter = (a = 500, b?: ErrorBody) => {
-  // handle passing an Error | StatusError directly in
   if (a instanceof Error) {
     const { message, ...err } = a
     a = a.status || 500
     b = {
       error: message || getMessage(a),
-      ...err,
+      ...err
     }
   }
 
-  b = {
+  return json({
     status: a,
     ...(typeof b === 'object' ? b : { error: b || getMessage(a) }),
-  }
-
-  return json(b, { status: a })
+  }, { status: a })
 }

--- a/src/withParams.ts
+++ b/src/withParams.ts
@@ -2,7 +2,7 @@ import { IRequest } from './Router'
 
 export const withParams = (request: IRequest): void => {
   request.proxy = new Proxy(request.proxy || request, {
-    get: (obj, prop) => obj[prop] !== undefined
+    get: (obj, prop) => obj[prop] != undefined
                     ? obj[prop].bind?.(request) || obj[prop]
                     : obj?.params?.[prop]
   })


### PR DESCRIPTION
### Description
This adds support for passthrough options (e.g. `port` in a Bun service), as well as the following specific options:
- `after`: what you would pass to a `.then()` chain on the `router.handle/router.fetch`.
- `errors`: what you would pass to a catch block.  if not defined, Router will still throw (uncaught). 

Adds appx. 45 bytes.

### Considerations
The bulk of the bytes added is to support the explicit try/catch block (and rethrow).  If we did not support errors in this, it would be closer to 460 bytes total (instead of 490).

### Example Usage
```ts
import { Router, RouterType, error, json, withParams } from '../src/index'

const router = Router({
  port: 3000,
  after: json,
  error: error, // long form for clarity
})

router
  .get('/json', () => ({ foo: 'bar' }))
  .get('/throw', (a) => a.b.c) // this is caught!
  .all('*', () => error(404))

export default router
```

### Type of Change (select one and follow subtasks)
- [ ] Documentation (README.md)
- [ ] Maintenance or repo-level work (e.g. linting, build, tests, refactoring, etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
  - [ ] I have included test coverage
- [ ] Breaking change (fix or feature that would cause existing functionality/userland code to not work as expected)
  - [ ] Explain why a breaking change is necessary:
- [ ] This change requires (or is) a documentation update
  - [ ] I have added necessary local documentation (if appropriate)
  - [ ] I have added necessary [itty.dev](https://github.com/kwhitley/itty.dev) documentation (if appropriate)
