### PR TITLE
DRAFT: adds support for genuine Header class in createResponse options

### DIFF
--- a/src/createResponse.spec.ts
+++ b/src/createResponse.spec.ts
@@ -35,6 +35,23 @@ describe('createResponse(mimeType: string, transform?: Function)', () => {
     expect(response.status).toBe(400)
   })
 
+  it('can pass in headers as Headers object', () => {
+    const payload = { foo: 'bar' }
+    const type = 'application/json; charset=utf-8'
+    const fooHeader = 'bar'
+    const headers = new Headers()
+    headers.append('fooHeader', 'foo')
+    const json = createResponse(type)
+
+    const response = json(payload, {
+      headers,
+      status: 400,
+    })
+
+    expect(response.headers.get('fooHeader')).toBe('foo')
+    expect(response.status).toBe(400)
+  })
+
   it('can pass in custom body transform function', async () => {
     const stars = createResponse('text/plain', (s) => s.replace(/./g, '*'))
 

--- a/src/createResponse.ts
+++ b/src/createResponse.ts
@@ -15,6 +15,13 @@ export const createResponse =
     body === undefined || body?.constructor.name === 'Response'
     ? body
     : new Response(transform ? transform(body) : body, {
-                    headers: { 'content-type': format, ...headers },
+                    headers: {
+                      'content-type': format,
+                      ...(headers.entries
+                          // @ts-expect-error - foul
+                          ? Object.fromEntries(headers)
+                          : headers
+                          ),
+                    },
                     ...rest
                   })


### PR DESCRIPTION
### Description
This adds support for a genuine `Headers` class within `createResponse()` (and thus `json`, `text`, etc).

#### Before (currently supported)
```ts
json({ foo: 'bar' }, {
  headers: {
    'custom-header': 'baz'
  }
})
```

#### After (adds support for the following as well)
```ts
const headers = new Headers()
headers.append('custom-value', 'baz')

json({ foo: 'bar' }, { 
  headers 
})
```

### Cost Evaluation
This adds appx. ~20 bytes to `createResponse`, and by proxy, to each of the downstream functions (`json`, `text`, etc).
My hunch is to skip this, as "not-worth-the-calories", given a simpler and less byte-intensive method already exists.

### Related Issue
[Link to the related issue:](https://github.com/kwhitley/itty-router/issues/210)

### Type of Change (select one and follow subtasks)
- [ ] Documentation (README.md)
- [ ] Maintenance or repo-level work (e.g. linting, build, tests, refactoring, etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
  - [x] I have included test coverage
- [ ] Breaking change (fix or feature that would cause existing functionality/userland code to not work as expected)
  - [ ] Explain why a breaking change is necessary:
- [ ] This change requires (or is) a documentation update
  - [ ] I have added necessary local documentation (if appropriate)
  - [ ] I have added necessary [itty.dev](https://github.com/kwhitley/itty.dev) documentation (if appropriate)
