### PR TITLE
fix: 216 withContent returning 500

### DIFF
--- a/src/withContent.spec.ts
+++ b/src/withContent.spec.ts
@@ -2,6 +2,7 @@ import 'isomorphic-fetch'
 import { describe, expect, it, vi } from 'vitest'
 import { Router } from './Router'
 import { withContent } from './withContent'
+import { StatusError } from './StatusError'
 
 describe('withContent (middleware)', () => {
   it('can access the awaited Response body as request.content', async () => {
@@ -18,5 +19,64 @@ describe('withContent (middleware)', () => {
     await router.post('/', withContent, handler).handle(request)
 
     expect(handler).toHaveReturnedWith({ foo: 'bar' })
+  })
+
+  it('throws an "Unexpected end of JSON input" error when no content is sent in the body', async () => {
+    const router = Router()
+    const handler = vi.fn(({ content }) => content)
+    const request = new Request('https://foo.bar', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+    })
+
+    await expect(
+      router.post('/', withContent, handler).handle(request)
+    ).rejects.toThrowError(/Unexpected end of JSON input/)
+
+    expect(handler).not.toHaveBeenCalled()
+    expect(handler).not.toHaveReturned()
+  })
+
+  it('returns a 400 when no content is sent in the body', async () => {
+    const router = Router()
+    const handler = vi.fn(({ content }) => content)
+    const request = new Request('https://foo.bar', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+    })
+
+    try {
+      await router.post('/', withContent, handler).handle(request)
+    } catch (e) {
+      expect(e).toBeInstanceOf(StatusError)
+      expect(e).toContain({ status: 400 })
+    }
+    expect(handler).not.toHaveBeenCalled()
+    expect(handler).not.toHaveReturned()
+  })
+
+  it('returns a 400 when invalid JSON content is sent in the body', async () => {
+    const router = Router()
+    const handler = vi.fn(({ content }) => content)
+    const request = new Request('https://foo.bar', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: 'foo is invalid JSON',
+    })
+
+    try {
+      await router.post('/', withContent, handler).handle(request)
+    } catch (e) {
+      expect(e).toBeInstanceOf(StatusError)
+      expect(e).toContain({ status: 400 })
+    }
+    expect(handler).not.toHaveBeenCalled()
+    expect(handler).not.toHaveReturned()
   })
 })

--- a/src/withContent.ts
+++ b/src/withContent.ts
@@ -1,11 +1,17 @@
 import { IRequest, IRequestStrict } from './Router'
+import { StatusError } from './StatusError'
 
 export type HasContent<ContentType> = {
-  content: ContentType,
+  content: ContentType
 } & IRequestStrict
 
 // withContent - embeds any request body as request.content
 export const withContent = async (request: IRequest): Promise<void> => {
   if (request.headers.get('content-type')?.includes('json'))
-    request.content = await request.json()
+    try {
+      request.content = await request.json()
+    } catch (e: unknown) {
+      const se = e as SyntaxError
+      throw new StatusError(400, se.message)
+    }
 }


### PR DESCRIPTION
Fix to return a `400` instead of a `500` when using the `withContent` middleware and sending no content or invalid JSON in the request body.

### Description
Wrapped the `withContent` middleware with a `try... catch` to capture any JSON parsing issues and return them as `400 Bad Request` instead of `500 Internal Server Error`. Added tests to check for the error, and that the router returns a `400` when no content or invalid JSON content is sent in the request body.

### Related Issue
Link to the related issue: [216: 'withContent' returns a '500' when no body is sent](https://github.com/kwhitley/itty-router/issues/216)

### Type of Change
- [x] Breaking change (fix that may cause userland code to not work as expected)
  - [x] If anyone relies upon the HTTP status code with the `withContent` middleware, this may cause an issue. Otherwise, this captures the invalid JSON input and returns a "more correct" HTTP status code.
