### PR TITLE
Fixed: set multiple cookie when using corsify fn

### DIFF
--- a/src/createCors.ts
+++ b/src/createCors.ts
@@ -76,14 +76,15 @@ export const createCors = (options: CorsOptions = {}) => {
       return response
 
     // Return new response with CORS headers.
+		Object.entries({
+			...rHeaders,
+			...allowOrigin,
+			'content-type': headers.get('content-type'),
+		}).forEach(([name, value]) => headers.append(name, value as string))
+
     return new Response(body, {
       status,
-      headers: {
-        ...Object.fromEntries(headers),
-        ...rHeaders,
-        ...allowOrigin,
-        'content-type': headers.get('content-type'),
-      },
+      headers,
     })
   }
 

--- a/src/createCors.ts
+++ b/src/createCors.ts
@@ -79,7 +79,6 @@ export const createCors = (options: CorsOptions = {}) => {
 		Object.entries({
 			...rHeaders,
 			...allowOrigin,
-			'content-type': headers.get('content-type'),
 		}).forEach(([name, value]) => headers.append(name, value as string))
 
     return new Response(body, {


### PR DESCRIPTION
### Description
The existing method did not allow for the setting of duplicate header keys, such as 'set-cookie'. 
Therefore, it has been modified to allow for duplicate keys by using headers.append().

### Related Issue
kwhitley/itty-router#207

### Type of Change (select one and follow subtasks)
- [x] Bug fix (non-breaking change which fixes an issue)
