### PR TITLE
v4.3 DRAFT: rename after stage to finally

### DIFF
--- a/example/bun-autorouter-advanced.ts
+++ b/example/bun-autorouter-advanced.ts
@@ -12,7 +12,7 @@ const router = AutoRouter({
   before: [
     (r: any) => { r.date = new Date },
   ],
-  after: [
+  finally: [
     (r: Response, request: IRequest) =>
       console.log(r.status, request.method, request.url, 'delivered in', Date.now() - request.date, 'ms from', request.date.toLocaleString()),
   ]

--- a/example/bun-router.ts
+++ b/example/bun-router.ts
@@ -11,7 +11,7 @@ const logger = (response: Response, request: IRequest) => {
 const router = Router({
   port: 3001,
   before: [withParams],
-  after: [json, logger],
+  finally: [json, logger],
   catch: error,
 })
 

--- a/src/AutoRouter.spec.ts
+++ b/src/AutoRouter.spec.ts
@@ -67,10 +67,10 @@ describe(`SPECIFIC TESTS: AutoRouter`, () => {
         expect(handler).toHaveReturnedWith('number')
       })
 
-      describe('after: (response: Response, request: IRequest, ...args) - ResponseHandler', async () => {
+      describe('finally: (response: Response, request: IRequest, ...args) - ResponseHandler', async () => {
         it('modifies the response if returning non-null value', async () => {
           const router = AutoRouter({
-            after: [ () => true ]
+            finally: [ () => true ]
           }).get('*', () => 314)
 
           const response = await router.fetch(toReq('/'))
@@ -79,7 +79,7 @@ describe(`SPECIFIC TESTS: AutoRouter`, () => {
 
         it('does not modify the response if returning null values', async () => {
           const router = AutoRouter({
-            after: [
+            finally: [
               () => {},
               () => undefined,
               () => null,

--- a/src/AutoRouter.ts
+++ b/src/AutoRouter.ts
@@ -1,10 +1,8 @@
+import { RouteHandler } from 'IttyRouter'
+import { ResponseHandler, Router, RouterOptions } from './Router'
 import { error } from './error'
 import { json } from './json'
 import { withParams } from './withParams'
-import { Router, RouterOptions} from './Router'
-import { RouteHandler } from 'IttyRouter'
-import { ResponseFormatter } from './createResponse'
-import { ResponseHandler } from './Router'
 
 type AutoRouterOptions = {
   missing?: RouteHandler

--- a/src/AutoRouter.ts
+++ b/src/AutoRouter.ts
@@ -4,17 +4,18 @@ import { withParams } from './withParams'
 import { Router, RouterOptions} from './Router'
 import { RouteHandler } from 'IttyRouter'
 import { ResponseFormatter } from './createResponse'
+import { ResponseHandler } from './Router'
 
 type AutoRouterOptions = {
   missing?: RouteHandler
-  format?: ResponseFormatter
+  format?: ResponseHandler
 } & RouterOptions
 
-// MORE FINE-GRAINED/SIMPLIFIED CONTROL, BUT CANNOT FULLY REPLACE BEFORE/AFTER STAGES
+// MORE FINE-GRAINED/SIMPLIFIED CONTROL, BUT CANNOT FULLY REPLACE BEFORE/FINALLY STAGES
 export const AutoRouter = ({
   format = json,
   missing = () => error(404),
-  after = [],
+  finally: f = [],
   before = [],
   ...options }: AutoRouterOptions = {}
 ) => Router({
@@ -23,19 +24,19 @@ export const AutoRouter = ({
     ...before
   ],
   catch: error,
-  after: [
+  finally: [
     (r: any, ...args) => r ?? missing(r, ...args),
     format,
-    ...after,
+    ...f,
   ],
   ...options,
 })
 
-// LESS FINE-GRAINED CONTROL, BUT CAN COMPLETELY REPLACE BEFORE/AFTER STAGES
+// LESS FINE-GRAINED CONTROL, BUT CAN COMPLETELY REPLACE BEFORE/FINALLY STAGES
 // export const AutoRouter2 = ({ ...options }: RouterOptions = {}) => Router({
 //   before: [withParams],
 //   onError: [error],
-//   after: [
+//   finally: [
 //     (r: any) => r ?? error(404),
 //     json,
 //   ],

--- a/src/IttyRouter.ts
+++ b/src/IttyRouter.ts
@@ -39,7 +39,7 @@ export type RouteEntry = [
 ]
 
 // this is the generic "Route", which allows per-route overrides
-export type Route = <RequestType = IRequest, Args extends any[] = any[], RT = RouterType>(
+export type Route = <RequestType = IRequest, Args extends any[] = any[], RT = IttyRouterType>(
   path: string,
   ...handlers: RouteHandler<RequestType, Args>[]
 ) => RT

--- a/src/Router.spec.ts
+++ b/src/Router.spec.ts
@@ -49,14 +49,14 @@ describe(`SPECIFIC TESTS: Router`, () => {
     expect(router2.fetch(toReq('/'))).rejects.toThrow()
   })
 
-  it('an error in the after stage will still be caught with a catch handler', async () => {
+  it('an error in the finally stage will still be caught with a catch handler', async () => {
     const handler = vi.fn(r => r instanceof Error)
     const router1 = Router({
-      after: [a => a.b.c],
+      finally: [a => a.b.c],
       catch: handler
     }).get('/', () => 'hey!')
     const router2 = Router({
-      after: [a => a.b.c],
+      finally: [a => a.b.c],
     }).get('/', () => 'hey!')
 
     const response1 = await router1.fetch(toReq('/'))
@@ -65,26 +65,26 @@ describe(`SPECIFIC TESTS: Router`, () => {
     expect(router2.fetch(toReq('/'))).rejects.toThrow()
   })
 
-  it('catch and after stages have access to request and args', async () => {
+  it('catch and finally stages have access to request and args', async () => {
     const request = toReq('/')
     const arg1 = { foo: 'bar' }
 
     const errorHandler = vi.fn((a,b,c) => [b.url, c])
-    const afterHandler = vi.fn((a,b,c) => [a, b.url, c])
+    const finallyHandler = vi.fn((a,b,c) => [a, b.url, c])
     const router = Router({
       catch: errorHandler,
-      after: [ afterHandler ],
+      finally: [ finallyHandler ],
     })
     .get('/', a => a.b.c)
 
     await router.fetch(toReq('/'), arg1)
     expect(errorHandler).toHaveReturnedWith([request.url, arg1])
-    expect(afterHandler).toHaveReturnedWith([[request.url, arg1], request.url, arg1])
+    expect(finallyHandler).toHaveReturnedWith([[request.url, arg1], request.url, arg1])
   })
 
-  it('allows modifying responses in an after stage', async () => {
+  it('allows modifying responses in an finally stage', async () => {
     const router = Router({
-      after: [r => Number(r) || 0],
+      finally: [r => Number(r) || 0],
     }).get('/:id?', r => r.params.id)
 
     const response1 = await router.fetch(toReq('/13'))
@@ -94,10 +94,10 @@ describe(`SPECIFIC TESTS: Router`, () => {
     expect(response2).toBe(0)
   })
 
-  it('after stages that return nothing will not modify response', async () => {
+  it('finally stages that return nothing will not modify response', async () => {
     const handler = vi.fn(() => {})
     const router = Router({
-      after: [
+      finally: [
         handler,
         r => Number(r) || 0,
       ],
@@ -109,20 +109,20 @@ describe(`SPECIFIC TESTS: Router`, () => {
     expect(handler).toHaveBeenCalled()
   })
 
-  it('can introspect/modify before/after/catch stages after initialization', async () => {
+  it('can introspect/modify before/finally/catch stages finally initialization', async () => {
     const handler1 = vi.fn(() => {})
     const handler2 = vi.fn(() => {})
     const router = Router({
       before: [ handler1, handler2 ],
-      after: [ handler1, handler2 ],
+      finally: [ handler1, handler2 ],
     })
 
     // manipulate
-    router.after.push(() => true)
+    router.finally.push(() => true)
 
     const response = await router.fetch(toReq('/'))
     expect(router.before.length).toBe(2)
-    expect(router.after.length).toBe(3)
+    expect(router.finally.length).toBe(3)
     expect(response).toBe(true)
   })
 })

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -12,19 +12,19 @@ import {
 export type ResponseHandler<ResponseType = any, RequestType = IRequest, Args extends any[] = any[]> =
     (response: ResponseType, request: RequestType, ...args: Args) => any
 
-export type ErrorHandler<ErrorOrResponse = Error, RequestType = IRequest, Args extends any[] = any[]> =
-    (response: ErrorOrResponse, request: RequestType, ...args: Args) => any
+export type ErrorHandler<ErrorType = Error, RequestType = IRequest, Args extends any[] = any[]> =
+    (response: ErrorType, request: RequestType, ...args: Args) => any
 
 export type RouterType<R = Route, Args extends any[] = any[]> = {
   before?: RouteHandler[]
   catch?: ErrorHandler
-  after?: ResponseHandler[]
+  finally?: ResponseHandler[]
 } & IttyRouterType<R, Args>
 
 export type RouterOptions = {
   before?: RouteHandler[]
   catch?: ErrorHandler
-  after?: ResponseHandler[]
+  finally?: ResponseHandler[]
 } & IttyRouterOptions
 
 export const Router = <
@@ -86,7 +86,7 @@ export const Router = <
       }
 
       try {
-        for (let handler of other.after || [])
+        for (let handler of other.finally || [])
           response = await handler(response, request.proxy ?? request, ...args) ?? response
       } catch(err: any) {
         if (!other.catch) throw err
@@ -97,12 +97,12 @@ export const Router = <
     },
   })
 
-// const afterHandler: RouteHandler<Response> = (response) => { response.headers }
+// const finallyHandler: RouteHandler<Response> = (response) => { response.headers }
 // const errorHandler: ErrorHandler<Error> = (err) => { err.message }
 
 // const router = Router({
-//   after: [
-//     afterHandler,
+//   finally: [
+//     finallyHandler,
 //     (response: Response) => { response.headers },
 //   ],
 //   catch: errorHandler,

--- a/src/SharedRouter.spec.ts
+++ b/src/SharedRouter.spec.ts
@@ -22,7 +22,7 @@ describe('Common Router Spec', () => {
         { path: '/foo', callback: vi.fn(extract), method: 'post' },
         {
           path: '/passthrough',
-          callback: vi.fn(({ method, name }) => ({ method, name })),
+          callback: vi.fn(r => r),
           method: 'get',
         },
       ]
@@ -190,13 +190,11 @@ describe('Common Router Spec', () => {
         })
 
         it('passes the entire original request through to the handler', async () => {
+          const request = toReq('/passthrough')
           const route = routes.find((r) => r.path === '/passthrough')
-          await router.fetch({ ...toReq('/passthrough'), name: 'miffles' })
+          await router.fetch(request)
 
-          expect(route?.callback).toHaveReturnedWith({
-            method: 'GET',
-            name: 'miffles',
-          })
+          expect(route?.callback).toHaveReturnedWith(request)
         })
 
         it('allows missing handler later in flow with "all" channel', async () => {

--- a/src/createResponse.spec.ts
+++ b/src/createResponse.spec.ts
@@ -74,6 +74,16 @@ describe('createResponse(mimeType: string, transform?: Function)', () => {
     expect(r2).toBeUndefined()
   })
 
+  it('will not apply a Request as 2nd options argument (using Request.url check method)', async () => {
+    const request = new Request('http://foo.bar', { headers: { foo: 'bar' }})
+    const response = json(1, request)
+    // const { ...restCheck } = request
+
+    // expect(restCheck.url).toBe('http://foo.bar/')
+    // expect(request.url).toBe('http://foo.bar/')
+    expect(response.headers.get('foo')).toBe(null)
+  })
+
   describe('format helpers', () => {
     const formats = [
       { name: 'json', fn: json, mime: 'application/json; charset=utf-8' },

--- a/src/createResponse.spec.ts
+++ b/src/createResponse.spec.ts
@@ -59,11 +59,12 @@ describe('createResponse(mimeType: string, transform?: Function)', () => {
     expect(body).toBe('***')
   })
 
-  it('will ignore a Response, to allow downstream use', async () => {
+  it('will ignore a Response, to allow downstream use (will not modify headers)', async () => {
     const r1 = json({ foo: 'bar' })
-    const r2 = json(r1)
+    const r2 = text(r1)
 
     expect(r2).toBe(r1)
+    expect(r2.headers.get('content-type')?.includes('text')).toBe(false)
   })
 
   it('will ignore an undefined body', async () => {

--- a/src/createResponse.ts
+++ b/src/createResponse.ts
@@ -11,17 +11,16 @@ export const createResponse =
     format = 'text/plain; charset=utf-8',
     transform?: BodyTransformer
   ): ResponseFormatter =>
-  (body, { headers = {}, ...rest } = {}) =>
-    body === undefined || body?.constructor.name === 'Response'
+  (body, { ...options } = {}) =>
+    body === undefined || body instanceof Response // skip function if undefined or an existing Response
     ? body
     : new Response(transform ? transform(body) : body, {
+                    ...options,
                     headers: {
                       'content-type': format,
-                      ...(headers.entries
+                      ...options.headers?.entries
                           // @ts-expect-error - foul
-                          ? Object.fromEntries(headers)
-                          : headers
-                          ),
+                          ? Object.fromEntries(options.headers)
+                          : options.headers
                     },
-                    ...rest
                   })

--- a/src/createResponse.ts
+++ b/src/createResponse.ts
@@ -6,21 +6,15 @@ export interface BodyTransformer {
   (body: any): string
 }
 
-export const createResponse =
+ export const createResponse =
   (
     format = 'text/plain; charset=utf-8',
     transform?: BodyTransformer
   ): ResponseFormatter =>
-  (body, { ...options } = {}) =>
-    body === undefined || body instanceof Response // skip function if undefined or an existing Response
-    ? body
-    : new Response(transform ? transform(body) : body, {
-                    ...options,
-                    headers: {
-                      'content-type': format,
-                      ...options.headers?.entries
-                          // @ts-expect-error - foul
-                          ? Object.fromEntries(options.headers)
-                          : options.headers
-                    },
-                  })
+  (body, { ...options } = {}) => {
+    if (body === undefined || body instanceof Response) return body
+
+    const response = new Response(transform?.(body) ?? body, options)
+    response.headers.set('content-type', format)
+    return response
+  }

--- a/test/index.ts
+++ b/test/index.ts
@@ -11,10 +11,7 @@ export const toReq = (methodAndPath: string) => {
     method = 'GET'
   }
 
-  return {
-    method,
-    url: `https://example.com${path}`
-  }
+  return new Request(`https://example.com${path}`, { method })
 }
 
 export const extract = ({ params, query }) => ({ params, query })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,10 +10,10 @@
     "lib": ["esnext", "dom", "dom.iterable"],
     "listEmittedFiles": false,
     "listFiles": false,
-    "moduleResolution": "nodeNext",
     "noFallthroughCasesInSwitch": true,
     "pretty": true,
-    "resolveJsonModule": true,
+    // "moduleResolution": "nodeNext",  // disabled to be compatible with module: "esnext"
+    // "resolveJsonModule": true,       // disabled to be compatible with module: "esnext"
     "rootDir": "src",
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
### Description
Renames `after` stage to `finally` to better coincide with Promise nomenclature.
