### PR TITLE
v5.x DRAFT: fixed router types :)

### DIFF
--- a/example/request-types.ts
+++ b/example/request-types.ts
@@ -1,4 +1,4 @@
-import { IRequest, IRequestStrict, Router } from '../src/IttyRouter'
+import { IRequest, IRequestStrict, IttyRouter } from '../src/IttyRouter'
 
 type FooRequest = {
   foo: string
@@ -16,7 +16,7 @@ type Env = {
 type CF = [env: Env, ctx: ExecutionContext]
 
 // this router defines a global signature of <BarRequest, CF>
-const custom = Router<BarRequest, CF>()
+const custom = IttyRouter<BarRequest, CF>()
 
 custom
   .get('/', ({ bar, json }) => {
@@ -32,7 +32,11 @@ custom
     ctx.waitUntil
   })
 
-const router = Router({ base: '/' })
+  .get<FooRequest>('/', (request) => {
+    request.foo // found in FooRequest override
+  })
+
+const router = IttyRouter({ base: '/' })
 
 router
   // call custom HTTP method

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -1,12 +1,10 @@
 import {
-  Equal,
   IRequest,
   IttyRouterOptions,
   IttyRouterType,
   RequestLike,
   Route,
-  RouteHandler,
-  UniversalRoute
+  RouteHandler
 } from './IttyRouter'
 
 export type ResponseHandler<ResponseType = any, RequestType = IRequest, Args extends any[] = any[]> =
@@ -29,35 +27,32 @@ export type RouterOptions = {
 
 export const Router = <
   RequestType = IRequest,
-  Args extends any[] = any[],
-  RouteType = Equal<RequestType, IRequest> extends true ? Route : UniversalRoute<RequestType, Args>
->({ base = '', routes = [], ...other }: RouterOptions = {}): RouterType<RouteType, Args> =>
-  // @ts-expect-error TypeScript doesn't know that Proxy makes this work
+  Args extends any[] = any[]
+>({ base = '', routes = [], ...other }: RouterOptions = {}): RouterType<RequestType, Args> =>
   ({
     __proto__: new Proxy({}, {
       // @ts-expect-error (we're adding an expected prop "path" to the get)
-      get: (target: any, prop: string, receiver: RouterType, path: string) =>
-        prop == 'handle' ? receiver.fetch :
-          // @ts-expect-error - unresolved type
-          (route: string, ...handlers: RouteHandler<I>[]) =>
-            routes.push(
-              [
-                prop.toUpperCase?.(),
-                RegExp(`^${(path = (base + route)
-                  .replace(/\/+(\/|$)/g, '$1'))                       // strip double & trailing splash
-                  .replace(/(\/?\.?):(\w+)\+/g, '($1(?<$2>*))')       // greedy params
-                  .replace(/(\/?\.?):(\w+)/g, '($1(?<$2>[^$1/]+?))')  // named params and image format
-                  .replace(/\./g, '\\.')                              // dot in path
-                  .replace(/(\/?)\*/g, '($1.*)?')                     // wildcard
-                }/*$`),
-                handlers,                                             // embed handlers
-                path,                                                 // embed clean route path
-              ]
-            ) && receiver
+      get: (target: any, prop: string, receiver: object, path: string) =>
+        (route: string, ...handlers: RouteHandler<RequestType, Args>[]) =>
+          routes.push(
+            [
+              prop.toUpperCase(),
+              RegExp(`^${(path = (base + route)
+                .replace(/\/+(\/|$)/g, '$1'))                       // strip double & trailing splash
+                .replace(/(\/?\.?):(\w+)\+/g, '($1(?<$2>*))')       // greedy params
+                .replace(/(\/?\.?):(\w+)/g, '($1(?<$2>[^$1/]+?))')  // named params and image format
+                .replace(/\./g, '\\.')                              // dot in path
+                .replace(/(\/?)\*/g, '($1.*)?')                     // wildcard
+              }/*$`),
+              // @ts-expect-error - fiddly
+              handlers,                                             // embed handlers
+              path,                                                 // embed clean route path
+            ]
+          ) && receiver
     }),
     routes,
     ...other,
-    async fetch (request: RequestLike, ...args) {
+    async fetch (request: RequestLike, ...args: any) {
       let response,
           match,
           url = new URL(request.url),
@@ -95,27 +90,4 @@ export const Router = <
 
       return response
     },
-  })
-
-// const finallyHandler: RouteHandler<Response> = (response) => { response.headers }
-// const errorHandler: ErrorHandler<Error> = (err) => { err.message }
-
-// const router = Router({
-//   finally: [
-//     finallyHandler,
-//     (response: Response) => { response.headers },
-//   ],
-//   catch: errorHandler,
-// })
-
-// type CustomRequest = {
-//   foo: string
-// } & IRequest
-
-// router.before = [
-//   (r: CustomRequest | IRequest) => { r.foo }
-// ]
-
-// router.get<CustomRequest>('/', (r) => r.foo)
-
-
+  } as RouterType<RequestType, Args>)


### PR DESCRIPTION
# Changes

Previously in v4.x, you were forced to *either* use a universal Request type at the router level, *or* override routes individually using generics, but not both.

```ts
const router = <FooRequest>Router()

router.get('/', (request) => { request.foo })

// would not work, due to the router-level generic
// THIS NOW WORKS IN v5.x :)
router.get<BarRequest>('/', (request) => { request.foo })
```

Now, we can use both simultaneously.  A router-level generic for all routes within the router, and individual route-level generic overrides.

