### PR TITLE
DRAFT: V5 types update

### DIFF
--- a/example/bun-autorouter.ts
+++ b/example/bun-autorouter.ts
@@ -1,6 +1,24 @@
 import { AutoRouter } from '../src/AutoRouter'
+import { IRequest, IRequestStrict, RequestHandler } from '../src/IttyRouter'
+import { ResponseHandler } from '../src/Router'
 
-const router = AutoRouter({ port: 3001 })
+type BenchmarkedRequest = {
+  start: number
+} & IRequestStrict
+
+const withBenchmarking: RequestHandler<BenchmarkedRequest> = (request) => {
+  request.start = Date.now()
+}
+
+const logger: ResponseHandler<Response, BenchmarkedRequest> = (response, request) => {
+  console.log(response.status, request.url, 'served in', Date.now() - request.start, 'ms')
+}
+
+const router = AutoRouter({
+  port: 3001,
+  before: [],
+  finally: [logger],
+})
 
 router
   .get('/basic', () => new Response('Success!'))

--- a/example/bun-autorouter.ts
+++ b/example/bun-autorouter.ts
@@ -16,8 +16,8 @@ const logger: ResponseHandler<Response, BenchmarkedRequest> = (response, request
 
 const router = AutoRouter({
   port: 3001,
-  before: [],
-  finally: [logger],
+  before: [withBenchmarking, () => {}],
+  finally: [logger, () => {}],
 })
 
 router

--- a/example/bun-router.ts
+++ b/example/bun-router.ts
@@ -1,4 +1,4 @@
-import { IRequest } from 'IttyRouter'
+import { IRequest, IRequestStrict } from 'IttyRouter'
 import { Router } from '../src/Router'
 import { error } from '../src/error'
 import { json } from '../src/json'
@@ -8,7 +8,7 @@ const logger = (response: Response, request: IRequest) => {
   console.log(response.status, request.url, '@', new Date().toLocaleString())
 }
 
-const router = Router({
+const router = Router<IRequestStrict>({
   port: 3001,
   before: [withParams],
   finally: [json, logger],
@@ -18,7 +18,7 @@ const router = Router({
 router
   .get('/basic', () => new Response('Success!'))
   .get('/text', () => 'Success!')
-  .get('/params/:foo', ({ foo }) => foo)
+  .get<IRequest>('/params/:foo', ({ foo }) => foo)
   .get('/json', () => ({ foo: 'bar' }))
   .get('/throw', a => a.b.c)
   .all('*', () => error(404))

--- a/example/types/global-and-route-level-request.ts
+++ b/example/types/global-and-route-level-request.ts
@@ -1,0 +1,17 @@
+import { IRequestStrict } from 'IttyRouter'
+import { Router } from 'Router'
+
+const router = Router<IRequestStrict>()
+
+type FooRequest = {
+  foo: string
+} & IRequestStrict
+
+router
+  .get('/basic', () => new Response('Success!'))
+  .get('/text', () => 'Success!')
+  // .get('/params/:foo', ({ foo }) => foo)              // should NOT work
+  .get<FooRequest>('/params/:foo', ({ foo }) => foo)  // should work
+  .get('/json', () => ({ foo: 'bar' }))
+
+export default router

--- a/example/types/global-request.ts
+++ b/example/types/global-request.ts
@@ -1,0 +1,16 @@
+import { IRequestStrict } from 'IttyRouter'
+import { Router } from 'Router'
+
+type FooRequest = {
+  foo: string
+} & IRequestStrict
+
+const router = Router<FooRequest>()
+
+router
+  .get('/', (request) => {
+    request.foo // should work
+    // request.bar // should NOT work
+  })
+
+export default router

--- a/example/types/middleware.ts
+++ b/example/types/middleware.ts
@@ -1,0 +1,36 @@
+import { IRequestStrict, IRequest, IttyRouter, RequestHandler } from 'IttyRouter'
+
+type UserRequest = {
+  user: string
+} & IRequestStrict
+
+const router = IttyRouter()
+
+const withUser: RequestHandler<UserRequest> = (request) => {
+  request.user = 'Kevin'
+}
+
+router
+  // upstream request sees the request as IRequest (default), so anything goes
+  .get('/', (request) => {
+    request.user = 123 // allowed because IRequest
+  })
+
+  // then we add the middleware defined above as <UserRequest>
+  .all('*', withUser)
+
+  // and now downstream requests expect a UserRequest
+  .get('/', (request) => {
+    request.user = 123  // NOT VALID
+  })
+
+  // and if we ever need to restore control, add the generic back in
+  .get<IRequest>('/', (request) => {
+    request.user = 123 // now this is ok
+  })
+
+  .get('/', (request) => {
+    request.user = 123 // and so is this
+  })
+
+export default router

--- a/example/types/route-level-request.ts
+++ b/example/types/route-level-request.ts
@@ -1,0 +1,16 @@
+import { IRequestStrict } from 'IttyRouter'
+import { Router } from 'Router'
+
+type FooRequest = {
+  foo: string
+} & IRequestStrict
+
+const router = Router()
+
+router
+  .get<FooRequest>('/', (request) => {
+    request.foo // should work
+    // request.bar // should NOT work
+  })
+
+export default router

--- a/src/AutoRouter.ts
+++ b/src/AutoRouter.ts
@@ -1,11 +1,11 @@
-import { RouteHandler } from 'IttyRouter'
+import { RequestHandler } from 'IttyRouter'
 import { ResponseHandler, Router, RouterOptions } from './Router'
 import { error } from './error'
 import { json } from './json'
 import { withParams } from './withParams'
 
 type AutoRouterOptions = {
-  missing?: RouteHandler
+  missing?: RequestHandler
   format?: ResponseHandler
 } & RouterOptions
 

--- a/src/IttyRouter.ts
+++ b/src/IttyRouter.ts
@@ -1,21 +1,21 @@
 export type GenericTraps = Record<string, any>
 
 export type RequestLike = {
-  method: string,
-  url: string,
+  method: string
+  url: string
 } & GenericTraps
 
 export type IRequestStrict = {
-  method: string,
-  url: string,
-  route: string,
+  method: string
+  url: string
+  route: string
   params: {
-    [key: string]: string,
-  },
+    [key: string]: string
+  }
   query: {
-    [key: string]: string | string[] | undefined,
-  },
-  proxy?: any,
+    [key: string]: string | string[] | undefined
+  }
+  proxy?: any
 } & Request
 
 export type IRequest = IRequestStrict & GenericTraps
@@ -43,32 +43,22 @@ export type Route<R = IRequest, A extends Array<any> = any[]> = <RequestType = R
   ...handlers: RequestHandler<RequestType, Args>[]
 ) => IttyRouterType<RequestType, Args>
 
-// this is an alternative UniveralRoute, accepting generics (from upstream), but without
-// per-route overrides
-// export type UniversalRoute<RequestType extends IRequest = IRequest, Args extends any[] = any[]> = (
-//   path: string,
-//   ...handlers: RequestHandler<RequestType, Args>[]
-// ) => IttyRouterType<UniversalRoute<RequestType, Args>, Args>
-
-// helper function to detect equality in types (used to detect custom Request on router)
-export type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? true : false;
-
 export type CustomRoutes<R = Route> = {
-  [key: string]: R,
+  [key: string]: R
 }
 
 export type IttyRouterType<R = IRequest, A extends any[] = any[], Output = any> = {
-  __proto__: IttyRouterType<R>,
-  routes: RouteEntry[],
+  __proto__: IttyRouterType<R>
+  routes: RouteEntry[]
   fetch: <Args extends any[] = A>(request: RequestLike, ...extra: Args) => Promise<Output>
-  all: Route<R, A>,
-  delete: Route<R, A>,
-  get: Route<R, A>,
-  head: Route<R, A>,
-  options: Route<R, A>,
-  patch: Route<R, A>,
-  post: Route<R, A>,
-  put: Route<R, A>,
+  all: Route<R, A>
+  delete: Route<R, A>
+  get: Route<R, A>
+  head: Route<R, A>
+  options: Route<R, A>
+  patch: Route<R, A>
+  post: Route<R, A>
+  put: Route<R, A>
 } & CustomRoutes<Route<R, A>>
 
 export const IttyRouter = <

--- a/src/IttyRouter.ts
+++ b/src/IttyRouter.ts
@@ -28,8 +28,6 @@ export type IttyRouterOptions = {
 export type RequestHandler<R = IRequest, Args extends Array<any> = any[]> =
   (request: R, ...args: Args) => any
 
-// export type RouteHandler = RouteHandler
-
 export type RouteEntry = [
   httpMethod: string,
   match: RegExp,

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -2,9 +2,8 @@ import {
   IRequest,
   IttyRouterOptions,
   IttyRouterType,
-  RequestLike,
-  Route,
-  RequestHandler
+  RequestHandler,
+  RequestLike
 } from './IttyRouter'
 
 export type ResponseHandler<ResponseType = Response, RequestType = IRequest, Args extends any[] = any[]> =

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -4,23 +4,23 @@ import {
   IttyRouterType,
   RequestLike,
   Route,
-  RouteHandler
+  RequestHandler
 } from './IttyRouter'
 
-export type ResponseHandler<ResponseType = any, RequestType = IRequest, Args extends any[] = any[]> =
-    (response: ResponseType, request: RequestType, ...args: Args) => any
+export type ResponseHandler<ResponseType = Response, RequestType = IRequest, Args extends any[] = any[]> =
+    (response: ResponseType & any, request: RequestType & any, ...args: Args) => any
 
 export type ErrorHandler<ErrorType = Error, RequestType = IRequest, Args extends any[] = any[]> =
     (response: ErrorType, request: RequestType, ...args: Args) => any
 
-export type RouterType<R = Route, Args extends any[] = any[]> = {
-  before?: RouteHandler[]
+export type RouterType<R = IRequest, Args extends any[] = any[]> = {
+  before?: RequestHandler<any>[]
   catch?: ErrorHandler
   finally?: ResponseHandler[]
 } & IttyRouterType<R, Args>
 
 export type RouterOptions = {
-  before?: RouteHandler[]
+  before?: RequestHandler<any>[]
   catch?: ErrorHandler
   finally?: ResponseHandler[]
 } & IttyRouterOptions
@@ -33,7 +33,7 @@ export const Router = <
     __proto__: new Proxy({}, {
       // @ts-expect-error (we're adding an expected prop "path" to the get)
       get: (target: any, prop: string, receiver: object, path: string) =>
-        (route: string, ...handlers: RouteHandler<RequestType, Args>[]) =>
+        (route: string, ...handlers: RequestHandler<RequestType, Args>[]) =>
           routes.push(
             [
               prop.toUpperCase?.(),


### PR DESCRIPTION
### What this is
I'm testing various scenarios of handler definition/usage, and ensuring that our current type system works as intended.  This requires loosening the constraints on certain elements to allow custom-defined handlers to pass generic checks.

## Scenario 1
```ts
import { AutoRouter } from '../src/AutoRouter'
import { IRequest, IRequestStrict, RequestHandler } from '../src/IttyRouter'
import { ResponseHandler } from '../src/Router'

type BenchmarkedRequest = {
  start: number
} & IRequestStrict

const withBenchmarking: RequestHandler<BenchmarkedRequest> = (request) => {
  request.start = Date.now()
}

const logger: ResponseHandler<Response, BenchmarkedRequest> = (response, request) => {
  console.log(response.status, request.url, 'served in', Date.now() - request.start, 'ms')
}

const router = AutoRouter({
  port: 3001,
  before: [withBenchmarking, () => {}],
  finally: [logger, () => {}],
})

router
  .get('/basic', () => new Response('Success!'))
  .get('/text', () => 'Success!')
  .get('/params/:foo', ({ foo }) => foo)
  .get('/json', () => ({ foo: 'bar' }))
  .get('/throw', (a) => a.b.c)

export default router
```