### PR TITLE
docs: fix v4 -> v5 migrations link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
     - "catch" stage (single error handler)
   - added: AutoRouter (batteries-included Router)
   - fixed (TS): Routers types have been modified to allow both rotuer-level generics AND route-level generics in the same instance.
-  - docs: see Migration guide at http://localhost:5173/itty-router/migrations/v4-v5
+  - docs: see Migration guide at https://itty.dev/itty-router/migrations/v4-v5
 - **v4.2.2**
   - fixed: withContent should return undefined if request.body is undefined
 - **v4.2.1**


### PR DESCRIPTION
### Description
This simply updates the changelog to fix the migration info URL

### Related Issue
Link to the related issue:

### Type of Change (select one and follow subtasks)
- [x] Documentation (README.md)
- [ ] Maintenance or repo-level work (e.g. linting, build, tests, refactoring, etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
  - [ ] I have included test coverage
- [ ] Breaking change (fix or feature that would cause existing functionality/userland code to not work as expected)
  - [ ] Explain why a breaking change is necessary:
- [ ] This change requires (or is) a documentation update
  - [ ] I have added necessary local documentation (if appropriate)
  - [ ] I have added necessary [itty.dev](https://github.com/kwhitley/itty.dev) documentation (if appropriate)
