### PR TITLE
fix #233 - cors eats status message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 
+- **v5.0.6**
+  - fixed: corsify as replacing status codes (now mutates original response)
 - **v5.0.5**
   - fixed: corsify now properly ignores WebSocket responses
 - **v5.0.4**

--- a/src/cors.spec.ts
+++ b/src/cors.spec.ts
@@ -236,6 +236,15 @@ describe('cors(options?: CorsOptions)', () => {
         expect(corsified.headers.getSetCookie().length).toBe(2)
       })
 
+      it('will preserve existing status codes', async () => {
+        const { corsify } = cors()
+        const response = new Response(null, { status: 403 })
+        const corsified = corsify(response.clone())
+
+        expect(response.status).toBe(403)
+        expect(corsified.status).toBe(403)
+      })
+
       it('will not modify a websocket request', async () => {
         const { corsify } = cors()
         const response = new WebSocketResponse(null, { status: 101 }) as Response

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -77,15 +77,14 @@ export const cors = (options: CorsOptions = {}) => {
       || response.status == 101
     ) return response
 
-    return new Response(response.body, {
-      ...response,
-      // @ts-expect-error
-      headers: [
-        ...response.headers,
-        ['access-control-allow-origin', getAccessControlOrigin(request)],
-        ...Object.entries(corsHeaders),
-      ].filter(v => v[1]),
-    })
+    const origin = getAccessControlOrigin(request)
+    if (origin) response.headers.append('access-control-allow-origin', origin)
+
+    for (const [key, value] of Object.entries(corsHeaders)) {
+      if (value) response.headers.append(key, value)
+    }
+
+    return response
   }
 
   // Return corsify and preflight methods.


### PR DESCRIPTION
### Description
`corsify` was not transferring the status of Responses to the final CORS version.

### Related Issue
#233

### Solution
Instead of recreating the response, we'll simply append CORS headers.

### Type of Change (select one and follow subtasks)
- [ ] Documentation (README.md)
- [ ] Maintenance or repo-level work (e.g. linting, build, tests, refactoring, etc.)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
  - [ ] I have included test coverage
- [ ] Breaking change (fix or feature that would cause existing functionality/userland code to not work as expected)
  - [ ] Explain why a breaking change is necessary:
- [ ] This change requires (or is) a documentation update
  - [ ] I have added necessary local documentation (if appropriate)
  - [ ] I have added necessary [itty.dev](https://github.com/kwhitley/itty.dev) documentation (if appropriate)
