### PR TITLE
V5 fix cors headers reflection

### DIFF
--- a/examples/runtimes/node-autorouter.js
+++ b/examples/runtimes/node-autorouter.js
@@ -1,41 +1,12 @@
-const { error } = require("../../dist/index")
 const { AutoRouter } = require("../../dist/AutoRouter")
 const { createServerAdapter } = require("@whatwg-node/server")
 const http = require("http")
 
-const router = AutoRouter({
-  catch: (err) => {
-    console.log('ERROR', err.message, err.stack)
-
-    return error(500, err.stack)
-  }
-})
+const router = AutoRouter()
 
 router.get('*', () => "Hello itty-router v5")
 
-const serverAdapter = createServerAdapter(async (request) => {
-  // this works
-
-  const url = new URL(request.url)
-
-  console.log({
-    url: request.url,
-    newURL: url,
-    method: request.method,
-  })
-
-  request.query = {}
-  request.params = {}
-  request.route = '/foo'
-  request.proxy = new Proxy(request, {})
-
-  const slimRequest = {
-    method: request.method,
-    url: request.url,
-  }
-
-  return await router.fetch(request)
-})
+const serverAdapter = createServerAdapter(router.fetch)
 
 const httpServer = http.createServer(serverAdapter)
 

--- a/src/cors.spec.ts
+++ b/src/cors.spec.ts
@@ -32,6 +32,9 @@ const REGEXP_DENY_ORIGIN = /^https:\/\/google.com$/
 const BASIC_OPTIONS_REQUEST = toReq('OPTIONS /', {
   headers: { origin: TEST_ORIGIN },
 })
+const REQUEST_HEADERS_REQUEST = toReq('OPTIONS /', {
+  headers: { 'access-control-request-headers': 'x-foo' },
+})
 const BASIC_REQUEST = toReq('/', {
   headers: { origin: TEST_ORIGIN },
 })
@@ -178,6 +181,12 @@ describe('cors(options?: CorsOptions)', () => {
       it('responds with status 204', async () => {
         const response = await DEFAULT_ROUTER.fetch(BASIC_OPTIONS_REQUEST)
         expect(response.status).toBe(204)
+      })
+
+      it('reflects requested headers by default', async () => {
+        const response = await DEFAULT_ROUTER.fetch(REQUEST_HEADERS_REQUEST)
+        expect(response.status).toBe(204)
+        expect(response.headers.get('access-control-allow-headers')).toBe('x-foo')
       })
     })
   })

--- a/src/cors.spec.ts
+++ b/src/cors.spec.ts
@@ -198,7 +198,6 @@ describe('cors(options?: CorsOptions)', () => {
         const response = corsify(new Response(null))
         const response2 = corsify(new Response(null), BASIC_REQUEST)
         expect(response.headers.get('access-control-allow-origin')).toBe('*')
-        expect(response.headers.get('access-control-allow-methods')).toBe('*')
         expect(response2.headers.get('access-control-allow-origin')).toBe('*')
       })
 
@@ -232,6 +231,21 @@ describe('cors(options?: CorsOptions)', () => {
         const response2 = corsify(new Response(null), BASIC_REQUEST)
         expect(response.headers.get('access-control-allow-origin')).toBe(TEST_ORIGIN)
         expect(response2.headers.get('access-control-allow-origin')).toBe(TEST_ORIGIN)
+      })
+
+      it('will not NOT include preflight headers', async () => {
+        const { corsify } = cors({
+          allowHeaders: 'foo',
+          allowMethods: 'GET',
+          exposeHeaders: 'foo',
+          maxAge: 3600,
+        })
+        const corsified = corsify(new Response(null))
+
+        expect(corsified.headers.get('access-control-allow-methods')).toBeNull()
+        expect(corsified.headers.get('access-control-allow-headers')).toBeNull()
+        expect(corsified.headers.get('access-control-expose-headers')).toBeNull()
+        expect(corsified.headers.get('access-control-max-age')).toBeNull()
       })
 
       it('will safely preserve multiple cookies (or other identical header names)', async () => {

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -57,7 +57,7 @@ export const cors = (options: CorsOptions = {}) => {
     : origin
   }
 
-  const appendHeadersAndReturn = (response: Response, headers: Record<string, any>) => {
+  const appendHeadersAndReturn = (response: Response, headers: Record<string, any>): Response => {
     for (const [key, value] of Object.entries(headers)) {
       if (value) response.headers.append(key, value)
     }
@@ -86,12 +86,6 @@ export const cors = (options: CorsOptions = {}) => {
     // clone the response
     // response = response.clone()
 
-    // const origin = getAccessControlOrigin(request)
-    // if (origin) response.headers.append('access-control-allow-origin', origin)
-
-    // for (const [key, value] of Object.entries(corsHeaders)) {
-    //   if (value) response.headers.append(key, value)
-    // }
     return appendHeadersAndReturn(response, {
       'access-control-allow-origin': getAccessControlOrigin(request),
       ...corsHeaders

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -29,16 +29,6 @@ export const cors = (options: CorsOptions = {}) => {
     maxAge,
   } = options
 
-  // create generic CORS headers
-  const corsHeaders = {
-    // @ts-expect-error
-    'access-control-expose-headers': exposeHeaders?.join?.(',') ?? exposeHeaders, // include allowed headers
-    // @ts-expect-error
-    'access-control-allow-methods': allowMethods?.join?.(',') ?? allowMethods,  // include allowed methods
-    'access-control-max-age': maxAge,
-    'access-control-allow-credentials': credentials,
-  }
-
   const getAccessControlOrigin = (request?: Request): string => {
     const requestOrigin = request?.headers.get('origin') // may be null if no request passed
 
@@ -70,8 +60,13 @@ export const cors = (options: CorsOptions = {}) => {
 
       return appendHeadersAndReturn(response, {
         'access-control-allow-origin': getAccessControlOrigin(request),
+        // @ts-ignore
+        'access-control-allow-methods': allowMethods?.join?.(',') ?? allowMethods,  // include allowed methods
+        // @ts-ignore
+        'access-control-expose-headers': exposeHeaders?.join?.(',') ?? exposeHeaders, // include allowed headers
         'access-control-allow-headers': allowHeaders?.join?.(',') ?? allowHeaders ?? request.headers.get('access-control-request-headers'), // include allowed headers
-        ...corsHeaders,
+        'access-control-max-age': maxAge,
+        'access-control-allow-credentials': credentials,
       })
     } // otherwise ignore
   }
@@ -88,7 +83,7 @@ export const cors = (options: CorsOptions = {}) => {
 
     return appendHeadersAndReturn(response, {
       'access-control-allow-origin': getAccessControlOrigin(request),
-      ...corsHeaders
+      'access-control-allow-credentials': credentials,
     })
   }
 

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -31,7 +31,6 @@ export const cors = (options: CorsOptions = {}) => {
 
   // create generic CORS headers
   const corsHeaders: Record<string, any> = {
-    'access-control-allow-headers': allowHeaders?.join?.(',') ?? allowHeaders, // include allowed headers
     // @ts-expect-error
     'access-control-expose-headers': exposeHeaders?.join?.(',') ?? exposeHeaders, // include allowed headers
     // @ts-expect-error
@@ -64,6 +63,7 @@ export const cors = (options: CorsOptions = {}) => {
         status: 204,
         headers: Object.entries({
           'access-control-allow-origin': getAccessControlOrigin(request),
+          'access-control-allow-headers': allowHeaders?.join?.(',') ?? allowHeaders ?? request.headers.get('access-control-request-headers'), // include allowed headers
           ...corsHeaders,
         }).filter(v => v[1]),
       })
@@ -76,6 +76,9 @@ export const cors = (options: CorsOptions = {}) => {
       response?.headers?.get('access-control-allow-origin')
       || response.status == 101
     ) return response
+
+    // clone the response
+    // response = response.clone()
 
     const origin = getAccessControlOrigin(request)
     if (origin) response.headers.append('access-control-allow-origin', origin)


### PR DESCRIPTION
### Description
FIXES:
- [x] Corrects the included CORS headers, and their distribution between preflight and final responses
- [x] Reflects `requested-headers` as `allowed-headers` by default, unless specified (via options)

### Type of Change (select one and follow subtasks)
- [ ] Documentation (README.md)
- [ ] Maintenance or repo-level work (e.g. linting, build, tests, refactoring, etc.)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
  - [ ] I have included test coverage
- [ ] Breaking change (fix or feature that would cause existing functionality/userland code to not work as expected)
  - [ ] Explain why a breaking change is necessary:
- [ ] This change requires (or is) a documentation update
  - [ ] I have added necessary local documentation (if appropriate)
  - [ ] I have added necessary [itty.dev](https://github.com/kwhitley/itty.dev) documentation (if appropriate)
