### PR TITLE
DRAFT: v5.1 - adds withParams option to AutoRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 
+- **v5.1.0**
+  - added: withParams is now an option in AutoRouter (set to no-op to bypass)
 - **v5.0.10**
   - fixed: response formatters in finally stage could still cross pollute headers in Node
 - **v5.0.9**

--- a/src/AutoRouter.spec.ts
+++ b/src/AutoRouter.spec.ts
@@ -55,6 +55,14 @@ describe(`SPECIFIC TESTS: AutoRouter`, () => {
         expect(response.status).toBe(418)
       })
 
+      it('withParams: can replace the withParams middleware', async () => {
+        const handler = vi.fn(({ a, b, params }) => [a, b, params.a, params.b])
+        const router = AutoRouter({ withParams: () => {} }).get('/:a/:b', handler)
+
+        await router.fetch(toReq('/foo/bar'))
+        expect(handler).toHaveReturnedWith([undefined, undefined, 'foo', 'bar'])
+      })
+
       it('before: RouteHandler - adds upstream middleware', async () => {
         const handler = vi.fn(r => typeof r.date)
         const router = AutoRouter({

--- a/src/AutoRouter.ts
+++ b/src/AutoRouter.ts
@@ -2,7 +2,7 @@ import { Router } from './Router'
 import { error } from './error'
 import { json } from './json'
 import { AutoRouterOptions, AutoRouterType, IRequest } from './types'
-import { withParams } from './withParams'
+import { withParams as wp } from './withParams'
 
 export const AutoRouter = <
   RequestType extends IRequest = IRequest,
@@ -12,6 +12,7 @@ export const AutoRouter = <
   format = json,
   missing = () => error(404),
   finally: f = [],
+  withParams = wp,
   before = [],
   ...options }: AutoRouterOptions = {}
 ): AutoRouterType<RequestType, Args, ResponseType> => Router({

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -1,7 +1,5 @@
-import { createResponse } from './createResponse'
-
-export const websocket = (client: WebSocket, options: object = {}) =>
-  createResponse()(null, {
+export const websocket = (client: WebSocket, options?: ResponseInit) =>
+  new Response(null, {
     status: 101,
     webSocket: client,
     ...options,

--- a/src/withParams.spec.ts
+++ b/src/withParams.spec.ts
@@ -70,14 +70,4 @@ describe('withParams (middleware)', () => {
       testParam: 'testValue',
     })
   })
-
-  it('downstream handlers can access original Request through request.raw', async () => {
-    const handler = vi.fn(r => r.raw)
-    const router = Router().get('/', withParams, handler)
-    const request = toReq('/')
-
-    await router.fetch(request)
-
-    expect(handler).toHaveReturnedWith(request)
-  })
 })

--- a/src/withParams.spec.ts
+++ b/src/withParams.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { Router } from './Router'
 import { withParams } from './withParams'
+import { toReq } from '../lib/index'
 
 describe('withParams (middleware)', () => {
   it('allows accessing route params from the request itself', async () => {
@@ -68,5 +69,15 @@ describe('withParams (middleware)', () => {
       method: 'GET',
       testParam: 'testValue',
     })
+  })
+
+  it('downstream handlers can access original Request through request.raw', async () => {
+    const handler = vi.fn(r => r.raw)
+    const router = Router().get('/', withParams, handler)
+    const request = toReq('/')
+
+    await router.fetch(request)
+
+    expect(handler).toHaveReturnedWith(request)
   })
 })

--- a/src/withParams.spec.ts
+++ b/src/withParams.spec.ts
@@ -7,7 +7,7 @@ describe('withParams (middleware)', () => {
   it('allows accessing route params from the request itself', async () => {
     const router = Router()
     const handler = vi.fn(({ id, method }) => ({ id, method }))
-    const request = { method: 'GET', url: 'https://foo.bar/baz' }
+    const request = toReq('/baz')
 
     await router.get('/:id', withParams, handler).fetch(request)
 
@@ -37,7 +37,7 @@ describe('withParams (middleware)', () => {
   it('can be used as global upstream middleware', async () => {
     const router = Router()
     const handler = vi.fn(({ id, method }) => ({ id, method }))
-    const request = { method: 'GET', url: 'https://foo.bar/baz' }
+    const request = toReq('/baz')
 
     await router.all('*', withParams).get('/:id', handler).fetch(request)
 

--- a/src/withParams.ts
+++ b/src/withParams.ts
@@ -2,7 +2,7 @@ import { IRequest } from './types'
 
 export const withParams = (request: IRequest): void => {
   request.proxy = new Proxy(request.proxy ?? request, {
-    get: (obj, prop, receiver) =>
+    get: (obj, prop) =>
             obj[prop]?.bind?.(request)  // if prop exists (as function), return the function, bound to the original request
             ?? obj[prop]                // if prop exists, return it
             ?? obj?.params?.[prop]      // if no prop exists, try the params object

--- a/src/withParams.ts
+++ b/src/withParams.ts
@@ -1,7 +1,6 @@
 import { IRequest } from './types'
 
 export const withParams = (request: IRequest): void => {
-  request.raw = request.raw ?? request  // places reference to request in request.raw if safe to do so
   request.proxy = new Proxy(request.proxy ?? request, {
     get: (obj, prop, receiver) =>
             obj[prop]?.bind?.(request)  // if prop exists (as function), return the function, bound to the original request

--- a/src/withParams.ts
+++ b/src/withParams.ts
@@ -1,9 +1,11 @@
 import { IRequest } from './types'
 
 export const withParams = (request: IRequest): void => {
-  request.proxy = new Proxy(request.proxy || request, {
-    get: (obj, prop) => obj[prop] !== undefined
-                    ? obj[prop]?.bind?.(request) || obj[prop]
-                    : obj?.params?.[prop]
+  request.raw = request.raw ?? request  // places reference to request in request.raw if safe to do so
+  request.proxy = new Proxy(request.proxy ?? request, {
+    get: (obj, prop, receiver) =>
+            obj[prop]?.bind?.(request)  // if prop exists (as function), return the function, bound to the original request
+            ?? obj[prop]                // if prop exists, return it
+            ?? obj?.params?.[prop]      // if no prop exists, try the params object
   })
 }


### PR DESCRIPTION
# Changes
- adds `withParams` as an option (defaults to `withParams` to `AutoRouter`.  Set to a no-op to bypass.
- `websocket` (undocumented) now uses a standard `Response`, rather than `createResponse` (saves ~100 bytes)
- `withParams` internal has been restructured to save ~10 bytes

### Type of Change (select one and follow subtasks)
- [ ] Documentation (README.md)
- [ ] Maintenance or repo-level work (e.g. linting, build, tests, refactoring, etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
  - [x] I have included test coverage
- [ ] Breaking change (fix or feature that would cause existing functionality/userland code to not work as expected)
  - [ ] Explain why a breaking change is necessary:
- [ ] This change requires (or is) a documentation update
  - [ ] I have added necessary local documentation (if appropriate)
  - [ ] I have added necessary [itty.dev](https://github.com/kwhitley/itty.dev) documentation (if appropriate)
