### PR TITLE
Add missing generics to Router stages (in options)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Changelog
 
-- **v5.0.11**
+- **v5.0.13**
+  - fixed: Router/AutoRouter stages were not connected to router-level generics
+- **v5.0.12**
   - fixed: ./types was not being properly exported
 - **v5.0.10**
   - fixed: response formatters in finally stage could still cross pollute headers in Node

--- a/examples/types/additional-arguments.ts
+++ b/examples/types/additional-arguments.ts
@@ -1,9 +1,5 @@
-import { RequestHandler } from '../../src/types'
-import { IRequestStrict } from '../../src/types'
 import { Router } from '../../src/Router'
-import { IttyRouter } from '../../src/IttyRouter'
-import { AutoRouter } from '../../src/AutoRouter'
-import { IRequest } from 'itty-router'
+import { IRequest, IRequestStrict, RequestHandler } from '../../src/types'
 
 // we define our environment
 type Environment = { age: number }
@@ -28,7 +24,7 @@ router
   .get('/', (request, env) => {
     request.user = 'kevin' // invalid (strict)
     env.whatever = 123 // valid (any)
-    env.age = 123 // valid (any)
+    env.age = 123 // valid
   })
 
   // route-level overrides
@@ -39,7 +35,7 @@ router
   })
   // route-level overrides
   .get<IRequest, AlternativeArgs>('/', (request, env) => {
-    request.foo = 'bar' // invalid
+    request.foo = 'bar' // valid
     env.age = 123 // invalid
     env.name = 'Mittens' // valid
   })
@@ -52,5 +48,5 @@ router
   })
 
   .get('/', (request, env) => {
-    env.age = 'foo' // valid (any)
+    env.age = 'foo' // invalid
   })

--- a/examples/types/generics-router-stages.ts
+++ b/examples/types/generics-router-stages.ts
@@ -1,0 +1,33 @@
+import { error } from 'console'
+import { Router } from '../../src/Router'
+import { withParams } from '../../src/withParams'
+import { IRequest, IRequestStrict, RequestHandler } from '../../src/types'
+
+// we define our environment
+type Environment = { age: number }
+type Pet = { name: string }
+
+// and now both args combined (that Workers send to the .fetch())
+type Args = [Environment]
+type AlternativeArgs = [Pet]
+
+const router = Router<IRequestStrict, Args, Response>({
+  before: [
+    (request, env) => {
+      env.age = 123       // valid
+      env.foo             // invalid
+      request.foo         // invalid
+      request.body        // valid
+    },
+    withParams,
+  ],
+  catch: error,
+  finally: [
+    (response, request, env) => {
+      response.whatever   // valid (any)
+      env.age = 123       // valid
+      env.foo             // invalid
+      request.foo         // invalid
+    },
+  ]
+})

--- a/examples/types/ittyrouter-generics.ts
+++ b/examples/types/ittyrouter-generics.ts
@@ -1,4 +1,4 @@
-import { Router } from '../../src/Router'
+import { IttyRouter } from '../../src/IttyRouter'
 import { IRequest, IRequestStrict, RequestHandler } from '../../src/types'
 
 // we define our environment
@@ -17,7 +17,7 @@ export const withUser: RequestHandler<IRequest, Args> =
     env.name = 'Kevin' // invalid
   }
 
-const router = Router<IRequestStrict, Args>()
+const router = IttyRouter<IRequestStrict, Args>()
 
 router
   // before middleware

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itty-router",
-  "version": "5.0.12",
+  "version": "5.0.13",
   "description": "A tiny, zero-dependency router, designed to make beautiful APIs in any environment.",
   "main": "./index.js",
   "module": "./index.mjs",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -16,7 +16,6 @@ const files = (await globby('./src/*.ts', {
   types: path.replace('/src/', '/dist/').replace('.ts', '.d.ts'),
 })).sort((a, b) => a.shortPath.toLowerCase() < b.shortPath.toLowerCase() ? -1 : 1)
 
-
 // read original package.json
 const pkg = await fs.readJSON('./package.json')
 

--- a/src/AutoRouter.ts
+++ b/src/AutoRouter.ts
@@ -1,7 +1,7 @@
 import { Router } from './Router'
 import { error } from './error'
 import { json } from './json'
-import { AutoRouterOptions, AutoRouterType, IRequest, IRequestStrict} from './types'
+import { AutoRouterOptions, AutoRouterType, IRequest } from './types'
 import { withParams } from './withParams'
 
 export const AutoRouter = <

--- a/src/AutoRouter.ts
+++ b/src/AutoRouter.ts
@@ -1,7 +1,7 @@
 import { Router } from './Router'
 import { error } from './error'
 import { json } from './json'
-import { AutoRouterOptions, AutoRouterType, IRequest } from './types'
+import { AutoRouterOptions, AutoRouterType, IRequest, IRequestStrict} from './types'
 import { withParams } from './withParams'
 
 export const AutoRouter = <
@@ -13,17 +13,20 @@ export const AutoRouter = <
   missing = () => error(404),
   finally: f = [],
   before = [],
-  ...options }: AutoRouterOptions = {}
-): AutoRouterType<RequestType, Args, ResponseType> => Router({
+  ...options }: AutoRouterOptions<RequestType, Args, ResponseType> = {}
+) => Router<RequestType, Args, ResponseType>({
   before: [
+    // @ts-ignore
     withParams,
     ...before
   ],
+  // @ts-ignore
   catch: error,
   finally: [
+    // @ts-ignore
     (r: any, ...args) => r ?? missing(r, ...args),
     format,
     ...f,
   ],
   ...options,
-})
+}) as AutoRouterType<RequestType, Args, ResponseType>

--- a/src/IttyRouter.ts
+++ b/src/IttyRouter.ts
@@ -10,14 +10,13 @@ export const IttyRouter = <
   RequestType extends IRequest = IRequest,
   Args extends any[] = any[],
   ResponseType = any,
-  GlobalRequestType = RequestType,
->({ base = '', routes = [], ...other }: IttyRouterOptions = {}): IttyRouterType<RequestType, Args, ResponseType, GlobalRequestType> =>
+>({ base = '', routes = [], ...other }: IttyRouterOptions = {}): IttyRouterType<RequestType, Args, ResponseType> =>
 // @ts-ignore
   ({
     __proto__: new Proxy({}, {
       // @ts-expect-error (we're adding an expected prop "path" to the get)
       get: (target: any, prop: string, receiver: object, path: string) =>
-        (route: string, ...handlers: RequestHandler<GlobalRequestType, Args>[]) =>
+        (route: string, ...handlers: RequestHandler<RequestType, Args>[]) =>
           routes.push(
             [
               prop.toUpperCase(),

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -10,7 +10,7 @@ export const Router = <
   RequestType = IRequest,
   Args extends any[] = any[],
   ResponseType = any
->({ base = '', routes = [], ...other }: RouterOptions<RequestType, Args, ResponseType> = {}): RouterType<RequestType, Args, ResponseType> =>
+>({ base = '', routes = [], ...other }: RouterOptions<RequestType, Args> = {}): RouterType<RequestType, Args, ResponseType> =>
   ({
     __proto__: new Proxy({}, {
       // @ts-expect-error (we're adding an expected prop "path" to the get)

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -10,7 +10,7 @@ export const Router = <
   RequestType = IRequest,
   Args extends any[] = any[],
   ResponseType = any
->({ base = '', routes = [], ...other }: RouterOptions = {}): RouterType<RequestType, Args, ResponseType> =>
+>({ base = '', routes = [], ...other }: RouterOptions<RequestType, Args, ResponseType> = {}): RouterType<RequestType, Args, ResponseType> =>
   ({
     __proto__: new Proxy({}, {
       // @ts-expect-error (we're adding an expected prop "path" to the get)
@@ -72,4 +72,4 @@ export const Router = <
 
       return response
     },
-  } as RouterType<RequestType, Args>)
+  } as RouterType<RequestType, Args, ResponseType>)

--- a/src/types/AutoRouterOptions.ts
+++ b/src/types/AutoRouterOptions.ts
@@ -2,7 +2,11 @@ import { RequestHandler } from './RequestHandler'
 import { ResponseHandler } from './ResponseHandler'
 import { RouterOptions } from './RouterOptions'
 
-export type AutoRouterOptions = {
-  missing?: RequestHandler
+export type AutoRouterOptions<
+  RequestType,
+  Args extends any[],
+  ResponseType
+> = {
+  missing?: RequestHandler<RequestType, Args>
   format?: ResponseHandler
-} & RouterOptions
+} & RouterOptions<RequestType, Args, ResponseType>

--- a/src/types/AutoRouterType.ts
+++ b/src/types/AutoRouterType.ts
@@ -4,10 +4,10 @@ import { ResponseHandler } from './ResponseHandler'
 import { RouterType } from './RouterType'
 
 export type AutoRouterType<
-  R = IRequest,
+  RequestType = IRequest,
   Args extends any[] = any[],
   ResponseType = any
 > = {
-  missing?: RequestHandler
+  missing?: RequestHandler<RequestType, Args>
   format?: ResponseHandler
-} & RouterType<R, Args, ResponseType>
+} & RouterType<RequestType, Args, ResponseType>

--- a/src/types/ErrorHandler.ts
+++ b/src/types/ErrorHandler.ts
@@ -3,5 +3,6 @@ import { IRequest } from './IRequest'
 
 export type ErrorHandler<
   ErrorType extends Error = StatusError,
-  RequestType = IRequest, Args extends any[] = any[]
+  RequestType = IRequest,
+  Args extends any[] = any[]
 > = (error: ErrorType, request: RequestType, ...args: Args) => any

--- a/src/types/IttyRouterType.ts
+++ b/src/types/IttyRouterType.ts
@@ -9,17 +9,16 @@ export type IttyRouterType<
   RequestType = IRequest,
   Args extends any[] = any[],
   ResponseType = any,
-  GlobalRequestType = RequestType,
 > = {
   __proto__: IttyRouterType<RequestType, Args, ResponseType>
   routes: RouteEntry[]
   fetch: <A extends any[] = Args>(request: RequestLike, ...extra: A) => Promise<ResponseType>
-  all: Route<GlobalRequestType, Args>
-  delete: Route<GlobalRequestType, Args>
-  get: Route<GlobalRequestType, Args>
-  head: Route<GlobalRequestType, Args>
-  options: Route<GlobalRequestType, Args>
-  patch: Route<GlobalRequestType, Args>
-  post: Route<GlobalRequestType, Args>
-  put: Route<GlobalRequestType, Args>
-} & CustomRoutes<Route<GlobalRequestType, Args>> & GenericTraps
+  all: Route<RequestType, Args>
+  delete: Route<RequestType, Args>
+  get: Route<RequestType, Args>
+  head: Route<RequestType, Args>
+  options: Route<RequestType, Args>
+  patch: Route<RequestType, Args>
+  post: Route<RequestType, Args>
+  put: Route<RequestType, Args>
+} & CustomRoutes<Route<RequestType, Args>> & GenericTraps

--- a/src/types/IttyRouterType.ts
+++ b/src/types/IttyRouterType.ts
@@ -6,20 +6,20 @@ import { RouteEntry } from './RouteEntry'
 import { CustomRoutes } from './CustomRoutes'
 
 export type IttyRouterType<
-  R = IRequest,
-  A extends any[] = any[],
+  RequestType = IRequest,
+  Args extends any[] = any[],
   ResponseType = any,
-  GlobalRequestType = R,
+  GlobalRequestType = RequestType,
 > = {
-  __proto__: IttyRouterType<R>
+  __proto__: IttyRouterType<RequestType, Args, ResponseType>
   routes: RouteEntry[]
-  fetch: <Args extends any[] = A>(request: RequestLike, ...extra: Args) => Promise<ResponseType>
-  all: Route<GlobalRequestType, A>
-  delete: Route<GlobalRequestType, A>
-  get: Route<GlobalRequestType, A>
-  head: Route<GlobalRequestType, A>
-  options: Route<GlobalRequestType, A>
-  patch: Route<GlobalRequestType, A>
-  post: Route<GlobalRequestType, A>
-  put: Route<GlobalRequestType, A>
-} & CustomRoutes<Route<GlobalRequestType, A>> & GenericTraps
+  fetch: <A extends any[] = Args>(request: RequestLike, ...extra: A) => Promise<ResponseType>
+  all: Route<GlobalRequestType, Args>
+  delete: Route<GlobalRequestType, Args>
+  get: Route<GlobalRequestType, Args>
+  head: Route<GlobalRequestType, Args>
+  options: Route<GlobalRequestType, Args>
+  patch: Route<GlobalRequestType, Args>
+  post: Route<GlobalRequestType, Args>
+  put: Route<GlobalRequestType, Args>
+} & CustomRoutes<Route<GlobalRequestType, Args>> & GenericTraps

--- a/src/types/RequestHandler.ts
+++ b/src/types/RequestHandler.ts
@@ -1,4 +1,6 @@
 import { IRequest } from './IRequest'
 
-export type RequestHandler<R = IRequest, Args extends Array<any> = any[]> =
-  (request: R, ...args: Args) => any
+export type RequestHandler<
+  RequestType = IRequest,
+  Args extends Array<any> = any[]
+> = (request: RequestType, ...args: Args) => any

--- a/src/types/ResponseHandler.ts
+++ b/src/types/ResponseHandler.ts
@@ -1,11 +1,11 @@
 import { IRequest } from './IRequest'
 
 export type ResponseHandler<
-  ResponseType = Response,
+  ResponseType = any,
   RequestType = IRequest,
   Args extends any[] = any[]
 > = (
-  response: ResponseType & any,
-  request: RequestType & any,
+  response: ResponseType,
+  request: RequestType,
   ...args: Args
 ) => any

--- a/src/types/RouteEntry.ts
+++ b/src/types/RouteEntry.ts
@@ -1,8 +1,9 @@
+import { IRequest } from './IRequest'
 import { RequestHandler } from './RequestHandler'
 
-export type RouteEntry = [
+export type RouteEntry<RequestType = IRequest, Args extends any[] = any[]> = [
   httpMethod: string,
   match: RegExp,
-  handlers: RequestHandler[],
+  handlers: RequestHandler<RequestType, Args>[],
   path?: string,
 ]

--- a/src/types/RouterOptions.ts
+++ b/src/types/RouterOptions.ts
@@ -1,10 +1,16 @@
+import { StatusError } from 'StatusError'
 import { ErrorHandler } from './ErrorHandler'
+import { IRequest } from './IRequest'
 import { IttyRouterOptions } from './IttyRouterOptions'
 import { RequestHandler } from './RequestHandler'
 import { ResponseHandler } from './ResponseHandler'
 
-export type RouterOptions = {
-  before?: RequestHandler<any>[]
-  catch?: ErrorHandler
-  finally?: ResponseHandler[]
+export type RouterOptions<
+  RequestType = IRequest,
+  Args extends any[] = [],
+  ResponseType = any
+> = {
+  before?: RequestHandler<RequestType, Args>[]
+  catch?: ErrorHandler<StatusError, RequestType, Args>
+  finally?: ResponseHandler<any, RequestType, Args>[]
 } & IttyRouterOptions

--- a/src/types/RouterOptions.ts
+++ b/src/types/RouterOptions.ts
@@ -8,7 +8,6 @@ import { ResponseHandler } from './ResponseHandler'
 export type RouterOptions<
   RequestType = IRequest,
   Args extends any[] = [],
-  ResponseType = any
 > = {
   before?: RequestHandler<RequestType, Args>[]
   catch?: ErrorHandler<StatusError, RequestType, Args>

--- a/src/types/RouterType.ts
+++ b/src/types/RouterType.ts
@@ -1,11 +1,16 @@
+import { StatusError } from 'StatusError'
 import { ErrorHandler } from './ErrorHandler'
 import { IRequest } from './IRequest'
 import { IttyRouterType } from './IttyRouterType'
 import { RequestHandler } from './RequestHandler'
 import { ResponseHandler } from './ResponseHandler'
 
-export type RouterType<R = IRequest, Args extends any[] = any[], ResponseType = any> = {
-  before?: RequestHandler<any>[]
-  catch?: ErrorHandler
-  finally?: ResponseHandler[]
-} & IttyRouterType<R, Args, ResponseType>
+export type RouterType<
+  RequestType = IRequest,
+  Args extends any[] = any[],
+  ResponseType = any
+> = {
+  before?: RequestHandler<RequestType, Args>[]
+  catch?: ErrorHandler<StatusError, RequestType, Args>
+  finally?: ResponseHandler<any, RequestType, Args>[]
+} & IttyRouterType<RequestType, Args, ResponseType>


### PR DESCRIPTION
### Description
Router generics did not extend to `before` and `finally` stages in router options.

### Type of Change (select one and follow subtasks)
- [ ] Documentation (README.md)
- [ ] Maintenance or repo-level work (e.g. linting, build, tests, refactoring, etc.)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
  - [ ] I have included test coverage
- [ ] Breaking change (fix or feature that would cause existing functionality/userland code to not work as expected)
  - [ ] Explain why a breaking change is necessary:
- [x] This change requires (or is) a documentation update
  - [ ] I have added necessary local documentation (if appropriate)
  - [ ] I have added necessary [itty.dev](https://github.com/kwhitley/itty.dev) documentation (if appropriate)
