### PR TITLE
fix express.js example

### DIFF
--- a/examples/runtimes/express.js
+++ b/examples/runtimes/express.js
@@ -1,16 +1,19 @@
 import express from 'express'
 import { Router, error, json } from 'itty-router'
 import 'isomorphic-fetch'
+import { createServerAdapter } from '@whatwg-node/server'
 
 const app = express()
 
 const router = Router()
 
-router.get('/', () => 'Success!').all('*', () => error(404))
+router.get('/', () => 'Success!')
+router.all('*', () => error(404))
 
-const handle = (request) => router.handle(request).then(json).catch(error)
+const handle = (request) => router.fetch(request).then(json).catch(error)
 
-app.use(handle)
+const ittyServer = createServerAdapter(handle)
+app.use(ittyServer.handle)
 
 app.listen(3001)
 console.log('listening at https://localhost:3001')


### PR DESCRIPTION
Should be using `createServerAdapter` adapter to convert to express-compatible handler. Based on this issue conversation: https://github.com/kwhitley/itty-router/issues/246#issuecomment-2110506175

### Description
v5 changes created regression in the way `express` handled `router.handle`. The right way is anyway to use `createServerAdapter` (from `@whatwg-node/server`) to make itty's router express-compatible.

### Related Issue
Link to the related issue: https://github.com/kwhitley/itty-router/issues/246#issuecomment-2110506175

### Type of Change (select one and follow subtasks)
- [] Documentation (README.md)
- [ ] Maintenance or repo-level work (e.g. linting, build, tests, refactoring, etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
  - [ ] I have included test coverage
- [ ] Breaking change (fix or feature that would cause existing functionality/userland code to not work as expected)
  - [ ] Explain why a breaking change is necessary:
- [X] This change requires (or is) a documentation update
  - [ ] I have added necessary local documentation (if appropriate)
  - [ ] I have added necessary [itty.dev](https://github.com/kwhitley/itty.dev) documentation (if appropriate)
