### PR TITLE
fix: corsify issue "can't modify immutable headers"

### DIFF
--- a/src/cors.ts
+++ b/src/cors.ts
@@ -78,7 +78,13 @@ export const cors = (options: CorsOptions = {}) => {
       || response.status == 101
     ) return response
 
-    return appendHeadersAndReturn(response.clone(), {
+    const responseCopy = new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    })
+
+    return appendHeadersAndReturn(responseCopy, {
       'access-control-allow-origin': getAccessControlOrigin(request),
       'access-control-allow-credentials': credentials,
     })


### PR DESCRIPTION
### Description

A fix was implemented in https://github.com/kwhitley/itty-router/commit/74f63abb25d12666e7c05e5e82fcf7432f8dbda4 to clone the response in `corsify` in order to avoid this error:
```
{
  "status": 500,
  "error": "Can't modify immutable headers."
}
```

Unfortunately, it seems not to be enough, and we're still having the issue with Cloudflare when a response is modified by `corsify`. A solution we found and implemented is to recreate a response by using `new Response(...)`.

Applying the fix here.

### Related Issue
Link to the related issue: related to #242

### Type of Change (select one and follow subtasks)
- [x] Bug fix (non-breaking change which fixes an issue)
