### PR TITLE
fix: Don’t pass response to AutoRouter missing handler

### DIFF
--- a/src/AutoRouter.spec.ts
+++ b/src/AutoRouter.spec.ts
@@ -60,7 +60,7 @@ describe(`SPECIFIC TESTS: AutoRouter`, () => {
         const router = AutoRouter({ missing })
         const request = toReq('/')
         await router.fetch(request)
-        expect(missing).toBeCalledWith(request)
+        expect(missing).toBeCalledWith(request['proxy'])
       })
       
       it('before: RouteHandler - adds upstream middleware', async () => {

--- a/src/AutoRouter.spec.ts
+++ b/src/AutoRouter.spec.ts
@@ -55,6 +55,14 @@ describe(`SPECIFIC TESTS: AutoRouter`, () => {
         expect(response.status).toBe(418)
       })
 
+      it('missing: RouteHandler - receives request as the first parameter', async () => {
+        const missing = vi.fn(() => {})
+        const router = AutoRouter({ missing })
+        const request = toReq('/')
+        await router.fetch(request)
+        expect(missing).toBeCalledWith(request)
+      })
+      
       it('before: RouteHandler - adds upstream middleware', async () => {
         const handler = vi.fn(r => typeof r.date)
         const router = AutoRouter({

--- a/src/AutoRouter.ts
+++ b/src/AutoRouter.ts
@@ -24,7 +24,7 @@ export const AutoRouter = <
   catch: error,
   finally: [
     // @ts-ignore
-    (r: any, ...args) => r ?? missing(r, ...args),
+    (r: any, ...args) => r ?? missing(...args),
     format,
     ...f,
   ],

--- a/src/types/RouterOptions.ts
+++ b/src/types/RouterOptions.ts
@@ -1,4 +1,4 @@
-import { StatusError } from 'StatusError'
+import { StatusError } from '../StatusError'
 import { ErrorHandler } from './ErrorHandler'
 import { IRequest } from './IRequest'
 import { IttyRouterOptions } from './IttyRouterOptions'

--- a/src/types/RouterType.ts
+++ b/src/types/RouterType.ts
@@ -1,4 +1,4 @@
-import { StatusError } from 'StatusError'
+import { StatusError } from '../StatusError'
 import { ErrorHandler } from './ErrorHandler'
 import { IRequest } from './IRequest'
 import { IttyRouterType } from './IttyRouterType'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    "baseUrl": "src",
     "declaration": true,
     "sourceMap": true,
     "esModuleInterop": true,
@@ -12,15 +11,13 @@
     "listFiles": false,
     "noFallthroughCasesInSwitch": true,
     "pretty": true,
-    // "moduleResolution": "nodeNext",  // disabled to be compatible with module: "esnext"
-    // "resolveJsonModule": true,       // disabled to be compatible with module: "esnext"
     "rootDir": "src",
     "skipLibCheck": true,
     "strict": true,
     "traceResolution": false,
     "outDir": "",
     "target": "esnext",
-    "module": "esnext",
+    "module": "Preserve",
     "types": ["@cloudflare/workers-types", "@types/node"]
   },
   "exclude": ["node_modules", "dist", "**/*.spec.ts", "examples"],


### PR DESCRIPTION
### Description

The missing handler is a RequestHandler, and the response should not be passed to it.

Probaly a breaking change for non typescript users.

(_Found that prettier is not applied to the codebase, or some prettier defaults is not set see `yarn prettier`_)

### Related Issue
Link to the related issue:

### Type of Change (select one and follow subtasks)
- [ ] Documentation (README.md)
- [ ] Maintenance or repo-level work (e.g. linting, build, tests, refactoring, etc.)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
  - [ ] I have included test coverage
- [ ] Breaking change (fix or feature that would cause existing functionality/userland code to not work as expected)
  - [ ] Explain why a breaking change is necessary:
- [ ] This change requires (or is) a documentation update
  - [ ] I have added necessary local documentation (if appropriate)
  - [ ] I have added necessary [itty.dev](https://github.com/kwhitley/itty.dev) documentation (if appropriate)
